### PR TITLE
Add ESP32 node firmware prototype

### DIFF
--- a/firmware/esp32-node/README.md
+++ b/firmware/esp32-node/README.md
@@ -1,0 +1,114 @@
+# VineGuard ESP32 Node Firmware
+
+Prototype firmware for the VineGuard in-field sensing node. The firmware targets ESP32 boards using the Arduino framework and PlatformIO. It samples soil and environmental sensors, publishes telemetry via LoRaWAN-style LoRa uplink or Wi-Fi/MQTT (lab mode), and persists runtime configuration in NVS.
+
+## Features
+
+- Modular sensor layer with swappable drivers (`AnalogSoilMoistureSensor`, `SoilTemperatureSensor`, `AmbientClimateSensor`, `LightSensor`, `BatteryMonitor`). Mock readings are emitted in `LAB_MODE` so the application can run on a desk without physical sensors.
+- FreeRTOS task architecture:
+  - `sensingTask` performs sensor acquisition when triggered.
+  - `uplinkTask` builds JSON telemetry and handles LoRa/MQTT transport.
+  - `powerTask` orchestrates sampling cadence, deep sleep, OTA triggers, and configuration reloads.
+- Configuration structure (`NodeConfig`) stored in NVS with defaults. Includes publish interval, sleep strategy, org/site/node identifiers, and MQTT credentials.
+- Transport abstraction with LoRa (Semtech SX1276/8) or Wi-Fi → MQTT (lab mode) via `ITelemetryPublisher` implementations.
+- MQTT command handling for `set_config` and OTA URL updates. OTA uses HTTPS (`ESPhttpUpdate`).
+- Status LED patterns for OK (slow blink), error (double blink), and OTA (fast blink) states.
+- Helper library (`SensorMath`, `TelemetryBuilder`) with unit tests executed on the `native` PlatformIO environment.
+
+## Project Layout
+
+```
+firmware/esp32-node/
+├── config.h.example        # Copy to config.h to override lab credentials or pin mappings
+├── include/                # Public headers for sensors, config, comms, LED, etc.
+├── lib/node_common/        # Pure helper modules with unit tests
+├── src/                    # Application sources and FreeRTOS tasks
+├── test/                   # Native unit tests for helper functions
+└── platformio.ini          # PlatformIO configuration (ESP32 + native test env)
+```
+
+## Building
+
+Install PlatformIO (CLI) and run:
+
+```bash
+pio run -d firmware/esp32-node          # build default LoRa-focused firmware
+pio run -e esp32dev_lab_wifi -d firmware/esp32-node   # build with LAB_MODE + Wi-Fi MQTT stub
+```
+
+Run helper unit tests on the host:
+
+```bash
+pio test -e native -d firmware/esp32-node
+```
+
+## Configuration
+
+Runtime configuration is persisted in NVS. Default values are compiled from `config_defaults.h`. To supply lab credentials (Wi-Fi SSID/password, MQTT broker, LoRa pin mapping), copy `config.h.example` to `config.h` and edit as needed.
+
+Example configuration command via MQTT (topic `/<org>/<site>/<node>/cmd`):
+
+```json
+{
+  "cmd": "set_config",
+  "config": {
+    "publishIntervalSeconds": 300,
+    "sleepStrategy": "stayAwake",
+    "useLoRa": false,
+    "mqtt": {
+      "host": "lab-broker.local",
+      "port": 1883,
+      "username": "lab",
+      "password": "lab"
+    },
+    "identity": {
+      "org": "vineguard",
+      "site": "lab",
+      "node": "esp32-node"
+    }
+  }
+}
+```
+
+To request an OTA update:
+
+```json
+{
+  "cmd": "ota",
+  "otaUrl": "https://example.com/firmware.bin"
+}
+```
+
+`set_config` payloads that contain `otaUrl` will also trigger the OTA process.
+
+## Telemetry Payload
+
+Telemetry is published as JSON matching the MQTT contract. Example:
+
+```json
+{
+  "version": "0.1.0",
+  "org": "vineguard",
+  "site": "lab",
+  "node": "esp32-node",
+  "ts": 1697049600000,
+  "measurements": {
+    "soilMoisture": 0.42,
+    "soilTempC": 19.5,
+    "ambientTempC": 21.1,
+    "ambientHumidity": 56.0,
+    "lightLux": 123.4,
+    "batteryVoltage": 3.71
+  }
+}
+```
+
+## LAB_MODE
+
+`LAB_MODE` (and `LAB_MODE_WIFI`) can be enabled via the `esp32dev_lab_wifi` PlatformIO environment. In this mode:
+
+- Sensors emit deterministic mock values for bench testing.
+- MQTT publishing is stubbed; telemetry is printed to the serial console and command messages can be injected by sending JSON lines over the serial port.
+- Deep sleep is disabled so tasks continue to run on the desk.
+
+Monitor serial output at 115200 baud to view telemetry samples and command responses.

--- a/firmware/esp32-node/config.h.example
+++ b/firmware/esp32-node/config.h.example
@@ -1,0 +1,19 @@
+#pragma once
+
+// Copy this file to config.h and adjust the credentials for your lab setup.
+#define WIFI_SSID "YourWiFiSSID"
+#define WIFI_PASSWORD "YourWiFiPassword"
+#define LAB_MQTT_BROKER "mqtt.example.com"
+#define LAB_MQTT_PORT 1883
+#define LAB_MQTT_USER "lab-user"
+#define LAB_MQTT_PASSWORD "lab-password"
+
+// LoRa radio pin mapping (adjust for your board)
+#define LORA_SCK 5
+#define LORA_MISO 19
+#define LORA_MOSI 27
+#define LORA_SS 18
+#define LORA_RST 14
+#define LORA_DIO0 26
+#define LORA_DIO1 33
+#define LORA_DIO2 32

--- a/firmware/esp32-node/include/CommManager.h
+++ b/firmware/esp32-node/include/CommManager.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <Arduino.h>
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "NodeConfig.h"
+
+class WiFiClientSecure;
+class PubSubClient;
+
+class ITelemetryPublisher {
+   public:
+    virtual ~ITelemetryPublisher() = default;
+    virtual bool begin(const NodeConfig &config) = 0;
+    virtual bool publish(const std::string &payload) = 0;
+    virtual void loop() = 0;
+    virtual bool isConnected() const = 0;
+    virtual void setCommandHandler(std::function<void(const String &)> handler) = 0;
+};
+
+class LoRaPublisher : public ITelemetryPublisher {
+   public:
+    LoRaPublisher();
+    bool begin(const NodeConfig &config) override;
+    bool publish(const std::string &payload) override;
+    void loop() override;
+    bool isConnected() const override;
+    void setCommandHandler(std::function<void(const String &)> handler) override;
+
+   private:
+    std::function<void(const String &)> handler_;
+    bool initialized_;
+};
+
+class WifiMqttPublisher : public ITelemetryPublisher {
+   public:
+    WifiMqttPublisher();
+    bool begin(const NodeConfig &config) override;
+    bool publish(const std::string &payload) override;
+    void loop() override;
+    bool isConnected() const override;
+    void setCommandHandler(std::function<void(const String &)> handler) override;
+
+   private:
+    void ensureConnected();
+    void handleMqttMessage(char *topic, uint8_t *payload, unsigned int length);
+
+    NodeConfig currentConfig_{};
+    std::function<void(const String &)> handler_;
+    String telemetryTopic_;
+    String commandTopic_;
+    uint32_t lastReconnectAttempt_;
+    bool mqttConnected_;
+    std::unique_ptr<class WiFiClientSecure> wifiClient_;
+    std::unique_ptr<class PubSubClient> mqttClient_;
+};
+
+std::unique_ptr<ITelemetryPublisher> createPublisher(bool useLoRa);

--- a/firmware/esp32-node/include/NodeConfig.h
+++ b/firmware/esp32-node/include/NodeConfig.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <Arduino.h>
+#include <Preferences.h>
+
+#include <functional>
+
+enum class SleepStrategy : uint8_t {
+    DeepSleep = 0,
+    StayAwake = 1,
+};
+
+struct NodeConfig {
+    uint32_t magic;
+    uint32_t version;
+    uint32_t publishIntervalSeconds;
+    SleepStrategy sleepStrategy;
+    bool useLoRa;
+    char mqttHost[64];
+    uint16_t mqttPort;
+    char mqttUser[32];
+    char mqttPassword[64];
+    char orgId[32];
+    char siteId[32];
+    char nodeId[32];
+    char otaUrl[128];
+};
+
+class NodeConfigManager {
+   public:
+    bool begin();
+    NodeConfig getConfig() const;
+    void setConfig(const NodeConfig &cfg);
+    bool load();
+    bool save();
+    bool updateFromJson(const String &json, bool &otaRequested);
+    String toJson() const;
+
+   private:
+    Preferences prefs_;
+    NodeConfig config_{};
+};
+
+NodeConfig makeDefaultConfig();

--- a/firmware/esp32-node/include/SensorInterfaces.h
+++ b/firmware/esp32-node/include/SensorInterfaces.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <Arduino.h>
+#include <memory>
+
+#include "SensorMath.h"
+
+struct SoilMoistureData {
+    uint16_t raw;
+    float normalized;
+};
+
+struct TemperatureData {
+    float temperatureC;
+};
+
+struct AmbientClimateData {
+    float temperatureC;
+    float humidity;
+};
+
+struct LightData {
+    float lux;
+};
+
+struct BatteryData {
+    float voltage;
+};
+
+template <typename T>
+class ISensor {
+   public:
+    virtual ~ISensor() = default;
+    virtual bool begin() = 0;
+    virtual bool read(T &out) = 0;
+};
+
+class AnalogSoilMoistureSensor : public ISensor<SoilMoistureData> {
+   public:
+    AnalogSoilMoistureSensor(uint8_t pin, uint16_t dryRef, uint16_t wetRef);
+    bool begin() override;
+    bool read(SoilMoistureData &out) override;
+
+   private:
+    uint8_t pin_;
+    uint16_t dryRef_;
+    uint16_t wetRef_;
+};
+
+class SoilTemperatureSensor : public ISensor<TemperatureData> {
+   public:
+    explicit SoilTemperatureSensor(uint8_t pin);
+    bool begin() override;
+    bool read(TemperatureData &out) override;
+
+   private:
+    uint8_t pin_;
+    std::unique_ptr<class OneWire> oneWire_;
+    std::unique_ptr<class DallasTemperature> driver_;
+};
+
+class AmbientClimateSensor : public ISensor<AmbientClimateData> {
+   public:
+    bool begin() override;
+    bool read(AmbientClimateData &out) override;
+};
+
+class LightSensor : public ISensor<LightData> {
+   public:
+    bool begin() override;
+    bool read(LightData &out) override;
+};
+
+class BatteryMonitor : public ISensor<BatteryData> {
+   public:
+    BatteryMonitor(uint8_t pin, uint16_t maxAdc, float referenceVoltage, float r1, float r2);
+    bool begin() override;
+    bool read(BatteryData &out) override;
+
+   private:
+    uint8_t pin_;
+    uint16_t maxAdc_;
+    float referenceVoltage_;
+    float r1_;
+    float r2_;
+};
+
+struct SensorSnapshot {
+    SoilMoistureData soilMoisture;
+    TemperatureData soilTemperature;
+    AmbientClimateData ambient;
+    LightData light;
+    BatteryData battery;
+};

--- a/firmware/esp32-node/include/StatusLed.h
+++ b/firmware/esp32-node/include/StatusLed.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <Arduino.h>
+
+enum class LedPattern { Off, Ok, Error, Ota };
+
+class StatusLed {
+   public:
+    StatusLed(uint8_t pin, bool activeHigh = true);
+    void begin();
+    void setPattern(LedPattern pattern);
+    void update();
+
+   private:
+    void applyState(bool on);
+
+    uint8_t pin_;
+    bool activeHigh_;
+    LedPattern pattern_;
+    uint32_t patternStart_;
+    bool lastState_;
+};

--- a/firmware/esp32-node/include/config_defaults.h
+++ b/firmware/esp32-node/include/config_defaults.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#ifndef WIFI_SSID
+#define WIFI_SSID "LAB_WIFI"
+#endif
+
+#ifndef WIFI_PASSWORD
+#define WIFI_PASSWORD "LAB_WIFI_PASSWORD"
+#endif
+
+#ifndef LAB_MQTT_BROKER
+#define LAB_MQTT_BROKER "lab-broker.local"
+#endif
+
+#ifndef LAB_MQTT_PORT
+#define LAB_MQTT_PORT 1883
+#endif
+
+#ifndef LAB_MQTT_USER
+#define LAB_MQTT_USER "lab"
+#endif
+
+#ifndef LAB_MQTT_PASSWORD
+#define LAB_MQTT_PASSWORD "lab"
+#endif
+
+#ifndef LORA_SCK
+#define LORA_SCK 5
+#endif
+#ifndef LORA_MISO
+#define LORA_MISO 19
+#endif
+#ifndef LORA_MOSI
+#define LORA_MOSI 27
+#endif
+#ifndef LORA_SS
+#define LORA_SS 18
+#endif
+#ifndef LORA_RST
+#define LORA_RST 14
+#endif
+#ifndef LORA_DIO0
+#define LORA_DIO0 26
+#endif
+#ifndef LORA_DIO1
+#define LORA_DIO1 33
+#endif
+#ifndef LORA_DIO2
+#define LORA_DIO2 32
+#endif

--- a/firmware/esp32-node/lib/node_common/SensorMath.cpp
+++ b/firmware/esp32-node/lib/node_common/SensorMath.cpp
@@ -1,0 +1,30 @@
+#include "SensorMath.h"
+
+#include <algorithm>
+
+float normalizeSensorReading(uint16_t raw, uint16_t minValue, uint16_t maxValue) {
+    if (minValue == maxValue) {
+        return 0.0f;
+    }
+    if (minValue > maxValue) {
+        std::swap(minValue, maxValue);
+    }
+    if (raw <= minValue) {
+        return 0.0f;
+    }
+    if (raw >= maxValue) {
+        return 1.0f;
+    }
+    const float span = static_cast<float>(maxValue - minValue);
+    const float normalized = (static_cast<float>(raw - minValue) / span);
+    return std::clamp(normalized, 0.0f, 1.0f);
+}
+
+float computeBatteryVoltage(uint16_t raw, uint16_t maxAdc, float referenceVoltage, float r1, float r2) {
+    if (maxAdc == 0 || referenceVoltage <= 0.0f || r2 <= 0.0f) {
+        return 0.0f;
+    }
+    const float voltageAtPin = (static_cast<float>(raw) / static_cast<float>(maxAdc)) * referenceVoltage;
+    const float dividerRatio = (r1 + r2) / r2;
+    return voltageAtPin * dividerRatio;
+}

--- a/firmware/esp32-node/lib/node_common/SensorMath.h
+++ b/firmware/esp32-node/lib/node_common/SensorMath.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <cstdint>
+
+float normalizeSensorReading(uint16_t raw, uint16_t minValue, uint16_t maxValue);
+float computeBatteryVoltage(uint16_t raw, uint16_t maxAdc, float referenceVoltage, float r1, float r2);

--- a/firmware/esp32-node/lib/node_common/TelemetryBuilder.cpp
+++ b/firmware/esp32-node/lib/node_common/TelemetryBuilder.cpp
@@ -1,0 +1,24 @@
+#include "TelemetryBuilder.h"
+
+#include <ArduinoJson.h>
+
+std::string buildTelemetryJson(const TelemetryData &data) {
+    StaticJsonDocument<512> doc;
+    doc["version"] = data.version;
+    doc["org"] = data.orgId;
+    doc["site"] = data.siteId;
+    doc["node"] = data.nodeId;
+    doc["ts"] = data.timestampMs;
+
+    JsonObject meas = doc.createNestedObject("measurements");
+    meas["soilMoisture"] = data.soilMoisture;
+    meas["soilTempC"] = data.soilTemperatureC;
+    meas["ambientTempC"] = data.ambientTemperatureC;
+    meas["ambientHumidity"] = data.ambientHumidity;
+    meas["lightLux"] = data.lightLux;
+    meas["batteryVoltage"] = data.batteryVoltage;
+
+    std::string output;
+    serializeJson(doc, output);
+    return output;
+}

--- a/firmware/esp32-node/lib/node_common/TelemetryBuilder.h
+++ b/firmware/esp32-node/lib/node_common/TelemetryBuilder.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+struct TelemetryData {
+    std::string version;
+    std::string orgId;
+    std::string siteId;
+    std::string nodeId;
+    uint64_t timestampMs;
+    float soilMoisture;
+    float soilTemperatureC;
+    float ambientTemperatureC;
+    float ambientHumidity;
+    float lightLux;
+    float batteryVoltage;
+};
+
+std::string buildTelemetryJson(const TelemetryData &data);

--- a/firmware/esp32-node/platformio.ini
+++ b/firmware/esp32-node/platformio.ini
@@ -1,0 +1,33 @@
+[platformio]
+default_envs = esp32dev
+
+[env:esp32dev]
+platform = espressif32
+board = esp32dev
+framework = arduino
+monitor_speed = 115200
+lib_deps =
+    bblanchon/ArduinoJson @ ^6.21.2
+    sandeepmistry/LoRa @ ^0.8.0
+    milesburton/DallasTemperature @ ^3.11.0
+    adafruit/Adafruit SHT31 Library @ ^2.2.0
+    claws/BH1750 @ ^1.2.1
+    knolleary/PubSubClient @ ^2.8
+build_flags =
+    -DCORE_DEBUG_LEVEL=0
+    -DVERSION=\"0.1.0\"
+
+[env:esp32dev_lab_wifi]
+extends = env:esp32dev
+build_flags =
+    ${env:esp32dev.build_flags}
+    -DLAB_MODE
+    -DLAB_MODE_WIFI
+
+[env:native]
+platform = native
+lib_deps =
+    bblanchon/ArduinoJson @ ^6.21.2
+build_flags =
+    -DVERSION=\"0.1.0\"
+test_build_project_src = no

--- a/firmware/esp32-node/src/CommManager.cpp
+++ b/firmware/esp32-node/src/CommManager.cpp
@@ -1,0 +1,214 @@
+#include "CommManager.h"
+
+#ifdef __has_include
+#  if __has_include("config.h")
+#    include "config.h"
+#  endif
+#endif
+#include "config_defaults.h"
+
+#include <SPI.h>
+#include <WiFi.h>
+#include <WiFiClientSecure.h>
+#include <functional>
+
+#include <LoRa.h>
+#include <PubSubClient.h>
+
+namespace {
+WifiMqttPublisher *g_wifiPublisher = nullptr;
+}
+
+LoRaPublisher::LoRaPublisher() : initialized_(false) {}
+
+bool LoRaPublisher::begin(const NodeConfig &config) {
+    (void)config;
+    SPI.begin(LORA_SCK, LORA_MISO, LORA_MOSI, LORA_SS);
+    LoRa.setPins(LORA_SS, LORA_RST, LORA_DIO0);
+    if (!LoRa.begin(915E6)) {
+        initialized_ = false;
+        Serial.println("[LoRa] Failed to start radio");
+        return false;
+    }
+    LoRa.enableCrc();
+    initialized_ = true;
+    Serial.println("[LoRa] Radio initialized");
+    return true;
+}
+
+bool LoRaPublisher::publish(const std::string &payload) {
+    if (!initialized_) {
+        return false;
+    }
+    LoRa.beginPacket();
+    LoRa.print(payload.c_str());
+    LoRa.endPacket(true);
+    return true;
+}
+
+void LoRaPublisher::loop() {
+    if (!initialized_) {
+        return;
+    }
+    int packetSize = LoRa.parsePacket();
+    if (packetSize <= 0) {
+        return;
+    }
+    String incoming;
+    while (LoRa.available()) {
+        incoming += static_cast<char>(LoRa.read());
+    }
+    if (handler_) {
+        handler_(incoming);
+    }
+}
+
+bool LoRaPublisher::isConnected() const { return initialized_; }
+
+void LoRaPublisher::setCommandHandler(std::function<void(const String &)> handler) { handler_ = handler; }
+
+WifiMqttPublisher::WifiMqttPublisher()
+    : lastReconnectAttempt_(0), mqttConnected_(false) {
+    g_wifiPublisher = this;
+    wifiClient_ = std::unique_ptr<WiFiClientSecure>(new WiFiClientSecure());
+    wifiClient_->setInsecure();
+    mqttClient_ = std::unique_ptr<PubSubClient>(new PubSubClient(*wifiClient_));
+}
+
+bool WifiMqttPublisher::begin(const NodeConfig &config) {
+    currentConfig_ = config;
+    telemetryTopic_ = String("/") + config.orgId + "/" + config.siteId + "/" + config.nodeId + "/telemetry";
+    commandTopic_ = String("/") + config.orgId + "/" + config.siteId + "/" + config.nodeId + "/cmd";
+    lastReconnectAttempt_ = 0;
+
+#ifdef LAB_MODE_WIFI
+    Serial.println("[LAB_MODE] WiFi MQTT publisher stub active");
+    mqttConnected_ = true;
+    return true;
+#else
+    WiFi.mode(WIFI_STA);
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    mqttClient_->setServer(config.mqttHost, config.mqttPort);
+    mqttClient_->setCallback([](char *topic, uint8_t *payload, unsigned int length) {
+        if (g_wifiPublisher) {
+            g_wifiPublisher->handleMqttMessage(topic, payload, length);
+        }
+    });
+    ensureConnected();
+    return true;
+#endif
+}
+
+bool WifiMqttPublisher::publish(const std::string &payload) {
+#ifdef LAB_MODE_WIFI
+    Serial.print("[LAB_MODE][MQTT] ");
+    Serial.print(telemetryTopic_);
+    Serial.print(" <= ");
+    Serial.println(payload.c_str());
+    return true;
+#else
+    ensureConnected();
+    if (!mqttClient_ || !mqttClient_->connected()) {
+        return false;
+    }
+    return mqttClient_->publish(telemetryTopic_.c_str(), payload.c_str());
+#endif
+}
+
+void WifiMqttPublisher::loop() {
+#ifdef LAB_MODE_WIFI
+    if (!handler_) {
+        return;
+    }
+    while (Serial.available()) {
+        String line = Serial.readStringUntil('\n');
+        line.trim();
+        if (line.length() == 0) {
+            continue;
+        }
+        if (line.charAt(0) == '{') {
+            handler_(line);
+        }
+    }
+#else
+    ensureConnected();
+    if (mqttClient_) {
+        mqttClient_->loop();
+    }
+#endif
+}
+
+bool WifiMqttPublisher::isConnected() const {
+#ifdef LAB_MODE_WIFI
+    return true;
+#else
+    return mqttConnected_ && mqttClient_ && mqttClient_->connected();
+#endif
+}
+
+void WifiMqttPublisher::setCommandHandler(std::function<void(const String &)> handler) {
+    handler_ = handler;
+}
+
+void WifiMqttPublisher::ensureConnected() {
+#ifdef LAB_MODE_WIFI
+    mqttConnected_ = true;
+    return;
+#else
+    if (WiFi.status() != WL_CONNECTED) {
+        if (millis() - lastReconnectAttempt_ > 5000) {
+            lastReconnectAttempt_ = millis();
+            Serial.println("[WiFi] Attempting reconnect");
+            WiFi.disconnect();
+            WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+        }
+        mqttConnected_ = false;
+        return;
+    }
+    if (!mqttClient_) {
+        return;
+    }
+    if (!mqttClient_->connected()) {
+        if (millis() - lastReconnectAttempt_ > 2000) {
+            lastReconnectAttempt_ = millis();
+            Serial.println("[MQTT] Connecting...");
+            if (mqttClient_->connect(currentConfig_.nodeId, currentConfig_.mqttUser, currentConfig_.mqttPassword)) {
+                mqttClient_->subscribe(commandTopic_.c_str());
+                mqttConnected_ = true;
+                Serial.println("[MQTT] Connected");
+            } else {
+                mqttConnected_ = false;
+            }
+        }
+    } else {
+        mqttConnected_ = true;
+    }
+#endif
+}
+
+void WifiMqttPublisher::handleMqttMessage(char *topic, uint8_t *payload, unsigned int length) {
+#ifndef LAB_MODE_WIFI
+    if (!handler_) {
+        return;
+    }
+    if (String(topic) != commandTopic_) {
+        return;
+    }
+    String message;
+    for (unsigned int i = 0; i < length; ++i) {
+        message += static_cast<char>(payload[i]);
+    }
+    handler_(message);
+#else
+    (void)topic;
+    (void)payload;
+    (void)length;
+#endif
+}
+
+std::unique_ptr<ITelemetryPublisher> createPublisher(bool useLoRa) {
+    if (useLoRa) {
+        return std::unique_ptr<ITelemetryPublisher>(new LoRaPublisher());
+    }
+    return std::unique_ptr<ITelemetryPublisher>(new WifiMqttPublisher());
+}

--- a/firmware/esp32-node/src/NodeConfig.cpp
+++ b/firmware/esp32-node/src/NodeConfig.cpp
@@ -1,0 +1,207 @@
+#include "NodeConfig.h"
+
+#ifdef __has_include
+#  if __has_include("config.h")
+#    include "config.h"
+#  endif
+#endif
+#include "config_defaults.h"
+
+#include <ArduinoJson.h>
+#include <cstring>
+
+namespace {
+constexpr uint32_t kMagic = 0x56474E44;  // 'VGND'
+constexpr uint32_t kConfigVersion = 1;
+}
+
+NodeConfig makeDefaultConfig() {
+    NodeConfig cfg{};
+    cfg.magic = kMagic;
+    cfg.version = kConfigVersion;
+    cfg.publishIntervalSeconds = 900;  // 15 minutes
+    cfg.sleepStrategy = SleepStrategy::DeepSleep;
+    cfg.useLoRa = true;
+    strlcpy(cfg.mqttHost, LAB_MQTT_BROKER, sizeof(cfg.mqttHost));
+    cfg.mqttPort = LAB_MQTT_PORT;
+    strlcpy(cfg.mqttUser, LAB_MQTT_USER, sizeof(cfg.mqttUser));
+    strlcpy(cfg.mqttPassword, LAB_MQTT_PASSWORD, sizeof(cfg.mqttPassword));
+    strlcpy(cfg.orgId, "vineguard", sizeof(cfg.orgId));
+    strlcpy(cfg.siteId, "lab", sizeof(cfg.siteId));
+    strlcpy(cfg.nodeId, "esp32-node", sizeof(cfg.nodeId));
+    cfg.otaUrl[0] = '\0';
+    return cfg;
+}
+
+bool NodeConfigManager::begin() {
+    if (!prefs_.begin("nodecfg", false)) {
+        return false;
+    }
+    config_ = makeDefaultConfig();
+    if (!load()) {
+        config_ = makeDefaultConfig();
+        return save();
+    }
+    return true;
+}
+
+NodeConfig NodeConfigManager::getConfig() const { return config_; }
+
+void NodeConfigManager::setConfig(const NodeConfig &cfg) { config_ = cfg; }
+
+bool NodeConfigManager::load() {
+    if (!prefs_.isKey("config")) {
+        config_ = makeDefaultConfig();
+        return true;
+    }
+    NodeConfig cfg{};
+    const size_t length = prefs_.getBytesLength("config");
+    if (length != sizeof(NodeConfig)) {
+        config_ = makeDefaultConfig();
+        return false;
+    }
+    prefs_.getBytes("config", &cfg, sizeof(NodeConfig));
+    if (cfg.magic != kMagic || cfg.version != kConfigVersion) {
+        config_ = makeDefaultConfig();
+        return false;
+    }
+    config_ = cfg;
+    return true;
+}
+
+bool NodeConfigManager::save() {
+    config_.magic = kMagic;
+    config_.version = kConfigVersion;
+    return prefs_.putBytes("config", &config_, sizeof(NodeConfig)) == sizeof(NodeConfig);
+}
+
+bool NodeConfigManager::updateFromJson(const String &json, bool &otaRequested) {
+    otaRequested = false;
+    StaticJsonDocument<512> doc;
+    const auto err = deserializeJson(doc, json);
+    if (err != DeserializationError::Ok) {
+        return false;
+    }
+
+    bool dirty = false;
+    if (doc.containsKey("publishIntervalSeconds")) {
+        const uint32_t value = doc["publishIntervalSeconds"].as<uint32_t>();
+        if (value != config_.publishIntervalSeconds && value >= 60) {
+            config_.publishIntervalSeconds = value;
+            dirty = true;
+        }
+    }
+    if (doc.containsKey("sleepStrategy")) {
+        const String strategy = doc["sleepStrategy"].as<String>();
+        SleepStrategy desired = config_.sleepStrategy;
+        if (strategy.equalsIgnoreCase("deepsleep")) {
+            desired = SleepStrategy::DeepSleep;
+        } else if (strategy.equalsIgnoreCase("stayawake")) {
+            desired = SleepStrategy::StayAwake;
+        }
+        if (desired != config_.sleepStrategy) {
+            config_.sleepStrategy = desired;
+            dirty = true;
+        }
+    }
+    if (doc.containsKey("useLoRa")) {
+        const bool useLoRa = doc["useLoRa"].as<bool>();
+        if (useLoRa != config_.useLoRa) {
+            config_.useLoRa = useLoRa;
+            dirty = true;
+        }
+    }
+    if (doc.containsKey("mqtt")) {
+        JsonObject mqtt = doc["mqtt"].as<JsonObject>();
+        if (mqtt.containsKey("host")) {
+            const String host = mqtt["host"].as<String>();
+            if (host.length() > 0 && host != config_.mqttHost) {
+                strlcpy(config_.mqttHost, host.c_str(), sizeof(config_.mqttHost));
+                dirty = true;
+            }
+        }
+        if (mqtt.containsKey("port")) {
+            const uint16_t port = mqtt["port"].as<uint16_t>();
+            if (port != 0 && port != config_.mqttPort) {
+                config_.mqttPort = port;
+                dirty = true;
+            }
+        }
+        if (mqtt.containsKey("username")) {
+            const String user = mqtt["username"].as<String>();
+            if (user != config_.mqttUser) {
+                strlcpy(config_.mqttUser, user.c_str(), sizeof(config_.mqttUser));
+                dirty = true;
+            }
+        }
+        if (mqtt.containsKey("password")) {
+            const String password = mqtt["password"].as<String>();
+            if (password != config_.mqttPassword) {
+                strlcpy(config_.mqttPassword, password.c_str(), sizeof(config_.mqttPassword));
+                dirty = true;
+            }
+        }
+    }
+    if (doc.containsKey("identity")) {
+        JsonObject ident = doc["identity"].as<JsonObject>();
+        if (ident.containsKey("org")) {
+            const String org = ident["org"].as<String>();
+            if (org.length() && org != config_.orgId) {
+                strlcpy(config_.orgId, org.c_str(), sizeof(config_.orgId));
+                dirty = true;
+            }
+        }
+        if (ident.containsKey("site")) {
+            const String site = ident["site"].as<String>();
+            if (site.length() && site != config_.siteId) {
+                strlcpy(config_.siteId, site.c_str(), sizeof(config_.siteId));
+                dirty = true;
+            }
+        }
+        if (ident.containsKey("node")) {
+            const String node = ident["node"].as<String>();
+            if (node.length() && node != config_.nodeId) {
+                strlcpy(config_.nodeId, node.c_str(), sizeof(config_.nodeId));
+                dirty = true;
+            }
+        }
+    }
+    if (doc.containsKey("otaUrl")) {
+        const String url = doc["otaUrl"].as<String>();
+        if (url.length() > 0 && url != config_.otaUrl) {
+            strlcpy(config_.otaUrl, url.c_str(), sizeof(config_.otaUrl));
+            otaRequested = true;
+            dirty = true;
+        }
+    }
+    if (dirty) {
+        save();
+    }
+    return dirty;
+}
+
+String NodeConfigManager::toJson() const {
+    StaticJsonDocument<512> doc;
+    doc["publishIntervalSeconds"] = config_.publishIntervalSeconds;
+    doc["sleepStrategy"] = config_.sleepStrategy == SleepStrategy::DeepSleep ? "deepSleep" : "stayAwake";
+    doc["useLoRa"] = config_.useLoRa;
+
+    JsonObject mqtt = doc.createNestedObject("mqtt");
+    mqtt["host"] = config_.mqttHost;
+    mqtt["port"] = config_.mqttPort;
+    mqtt["username"] = config_.mqttUser;
+    mqtt["password"] = config_.mqttPassword;
+
+    JsonObject ident = doc.createNestedObject("identity");
+    ident["org"] = config_.orgId;
+    ident["site"] = config_.siteId;
+    ident["node"] = config_.nodeId;
+
+    if (strlen(config_.otaUrl) > 0) {
+        doc["otaUrl"] = config_.otaUrl;
+    }
+
+    String json;
+    serializeJson(doc, json);
+    return json;
+}

--- a/firmware/esp32-node/src/SensorInterfaces.cpp
+++ b/firmware/esp32-node/src/SensorInterfaces.cpp
@@ -1,0 +1,138 @@
+#include "SensorInterfaces.h"
+
+#include <Arduino.h>
+#include <Wire.h>
+#include <cmath>
+
+#include <Adafruit_SHT31.h>
+#include <BH1750.h>
+#include <DallasTemperature.h>
+#include <OneWire.h>
+
+namespace {
+#ifndef LAB_MODE
+Adafruit_SHT31 sht31 = Adafruit_SHT31();
+BH1750 lightMeter;
+#endif
+}
+
+AnalogSoilMoistureSensor::AnalogSoilMoistureSensor(uint8_t pin, uint16_t dryRef, uint16_t wetRef)
+    : pin_(pin), dryRef_(dryRef), wetRef_(wetRef) {}
+
+bool AnalogSoilMoistureSensor::begin() {
+    pinMode(pin_, INPUT);
+    return true;
+}
+
+bool AnalogSoilMoistureSensor::read(SoilMoistureData &out) {
+#ifdef LAB_MODE
+    const float oscillation = 0.5f + 0.4f * sinf(millis() / 3000.0f);
+    const uint16_t minRef = wetRef_ > dryRef_ ? dryRef_ : wetRef_;
+    const uint16_t maxRef = wetRef_ > dryRef_ ? wetRef_ : dryRef_;
+    const uint16_t span = maxRef - minRef;
+    uint16_t raw = static_cast<uint16_t>(oscillation * span) + minRef;
+#else
+    uint16_t raw = analogRead(pin_);
+#endif
+    out.raw = raw;
+    out.normalized = normalizeSensorReading(raw, dryRef_, wetRef_);
+    return true;
+}
+
+SoilTemperatureSensor::SoilTemperatureSensor(uint8_t pin) : pin_(pin) {}
+
+bool SoilTemperatureSensor::begin() {
+#ifndef LAB_MODE
+    oneWire_.reset(new OneWire(pin_));
+    driver_.reset(new DallasTemperature(oneWire_.get()));
+    driver_->begin();
+#endif
+    return true;
+}
+
+bool SoilTemperatureSensor::read(TemperatureData &out) {
+#ifdef LAB_MODE
+    out.temperatureC = 18.0f + 3.0f * sinf(millis() / 5000.0f);
+    return true;
+#else
+    if (!driver_) {
+        return false;
+    }
+    driver_->requestTemperatures();
+    const float tempC = driver_->getTempCByIndex(0);
+    if (tempC == DEVICE_DISCONNECTED_C) {
+        return false;
+    }
+    out.temperatureC = tempC;
+    return true;
+#endif
+}
+
+bool AmbientClimateSensor::begin() {
+    Wire.begin();
+#ifndef LAB_MODE
+    if (!sht31.begin(0x44)) {
+        return false;
+    }
+#endif
+    return true;
+}
+
+bool AmbientClimateSensor::read(AmbientClimateData &out) {
+#ifdef LAB_MODE
+    out.temperatureC = 22.0f + 1.5f * sinf(millis() / 4000.0f);
+    out.humidity = 50.0f + 5.0f * cosf(millis() / 4500.0f);
+    return true;
+#else
+    const float temp = sht31.readTemperature();
+    const float humidity = sht31.readHumidity();
+    if (isnan(temp) || isnan(humidity)) {
+        return false;
+    }
+    out.temperatureC = temp;
+    out.humidity = humidity;
+    return true;
+#endif
+}
+
+bool LightSensor::begin() {
+    Wire.begin();
+#ifndef LAB_MODE
+    return lightMeter.begin(BH1750::CONTINUOUS_HIGH_RES_MODE);
+#else
+    return true;
+#endif
+}
+
+bool LightSensor::read(LightData &out) {
+#ifdef LAB_MODE
+    out.lux = 200.0f + 150.0f * sinf(millis() / 6000.0f);
+    return true;
+#else
+    out.lux = lightMeter.readLightLevel();
+    if (out.lux < 0) {
+        return false;
+    }
+    return true;
+#endif
+}
+
+BatteryMonitor::BatteryMonitor(uint8_t pin, uint16_t maxAdc, float referenceVoltage, float r1, float r2)
+    : pin_(pin), maxAdc_(maxAdc), referenceVoltage_(referenceVoltage), r1_(r1), r2_(r2) {}
+
+bool BatteryMonitor::begin() {
+    pinMode(pin_, INPUT);
+    return true;
+}
+
+bool BatteryMonitor::read(BatteryData &out) {
+#ifdef LAB_MODE
+    const float oscillation = 3.7f + 0.3f * sinf(millis() / 7000.0f);
+    out.voltage = oscillation;
+    return true;
+#else
+    const uint16_t raw = analogRead(pin_);
+    out.voltage = computeBatteryVoltage(raw, maxAdc_, referenceVoltage_, r1_, r2_);
+    return true;
+#endif
+}

--- a/firmware/esp32-node/src/StatusLed.cpp
+++ b/firmware/esp32-node/src/StatusLed.cpp
@@ -1,0 +1,53 @@
+#include "StatusLed.h"
+
+StatusLed::StatusLed(uint8_t pin, bool activeHigh)
+    : pin_(pin), activeHigh_(activeHigh), pattern_(LedPattern::Off), patternStart_(0), lastState_(false) {}
+
+void StatusLed::begin() {
+    pinMode(pin_, OUTPUT);
+    applyState(false);
+    patternStart_ = millis();
+}
+
+void StatusLed::setPattern(LedPattern pattern) {
+    if (pattern_ == pattern) {
+        return;
+    }
+    pattern_ = pattern;
+    patternStart_ = millis();
+}
+
+void StatusLed::update() {
+    const uint32_t now = millis();
+    bool on = false;
+
+    switch (pattern_) {
+        case LedPattern::Off:
+            on = false;
+            break;
+        case LedPattern::Ok: {
+            const uint32_t position = (now - patternStart_) % 2000U;
+            on = position < 150U;
+            break;
+        }
+        case LedPattern::Error: {
+            const uint32_t position = (now - patternStart_) % 2000U;
+            on = (position < 150U) || (position >= 300U && position < 450U);
+            break;
+        }
+        case LedPattern::Ota: {
+            const uint32_t position = (now - patternStart_) % 600U;
+            on = position < 300U;
+            break;
+        }
+    }
+
+    if (on != lastState_) {
+        applyState(on);
+        lastState_ = on;
+    }
+}
+
+void StatusLed::applyState(bool on) {
+    digitalWrite(pin_, activeHigh_ ? (on ? HIGH : LOW) : (on ? LOW : HIGH));
+}

--- a/firmware/esp32-node/src/main.cpp
+++ b/firmware/esp32-node/src/main.cpp
@@ -1,0 +1,381 @@
+#include <Arduino.h>
+#include <WiFi.h>
+#include <esp_sleep.h>
+#include <esp_timer.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/event_groups.h>
+#include <freertos/queue.h>
+#include <freertos/task.h>
+
+#include "CommManager.h"
+#include "NodeConfig.h"
+#include "SensorInterfaces.h"
+#include "StatusLed.h"
+#include "TelemetryBuilder.h"
+#include <ArduinoJson.h>
+
+#ifdef __has_include
+#  if __has_include("config.h")
+#    include "config.h"
+#  endif
+#endif
+#include "config_defaults.h"
+
+#include <HTTPClient.h>
+#include <HTTPUpdate.h>
+
+#include <string>
+
+#ifndef VERSION
+#define VERSION "dev"
+#endif
+
+namespace {
+constexpr uint8_t kSoilMoisturePin = 34;
+constexpr uint8_t kSoilTempPin = 4;
+constexpr uint8_t kBatteryPin = 35;
+#ifndef STATUS_LED_PIN
+constexpr uint8_t kStatusLedPin = 2;
+#else
+constexpr uint8_t kStatusLedPin = STATUS_LED_PIN;
+#endif
+
+constexpr uint16_t kSoilDryRef = 3200;
+constexpr uint16_t kSoilWetRef = 1400;
+constexpr uint16_t kAdcMax = 4095;
+constexpr float kAdcReferenceVoltage = 3.3f;
+constexpr float kBatteryR1 = 100000.0f;
+constexpr float kBatteryR2 = 10000.0f;
+
+AnalogSoilMoistureSensor soilMoistureSensor(kSoilMoisturePin, kSoilDryRef, kSoilWetRef);
+SoilTemperatureSensor soilTemperatureSensor(kSoilTempPin);
+AmbientClimateSensor ambientSensor;
+LightSensor lightSensor;
+BatteryMonitor batteryMonitor(kBatteryPin, kAdcMax, kAdcReferenceVoltage, kBatteryR1, kBatteryR2);
+
+NodeConfigManager configManager;
+NodeConfig currentConfig;
+std::unique_ptr<ITelemetryPublisher> publisher;
+StatusLed statusLed(kStatusLedPin);
+QueueHandle_t telemetryQueue = nullptr;
+EventGroupHandle_t systemEvents = nullptr;
+TaskHandle_t sensingTaskHandle = nullptr;
+TaskHandle_t uplinkTaskHandle = nullptr;
+TaskHandle_t powerTaskHandle = nullptr;
+SemaphoreHandle_t publisherMutex = nullptr;
+
+constexpr EventBits_t EVENT_SAMPLE_READY = BIT0;
+constexpr EventBits_t EVENT_UPLINK_COMPLETE = BIT1;
+
+struct TelemetryMessage {
+    SensorSnapshot snapshot;
+    uint64_t timestampMs;
+    bool success;
+};
+
+volatile bool configNeedsReinit = false;
+volatile bool otaRequested = false;
+String pendingOtaUrl;
+
+TelemetryMessage latestMessage{};
+
+void requestSample();
+void sensingTask(void *param);
+void uplinkTask(void *param);
+void powerTask(void *param);
+void handleCommand(const String &payload);
+void performOtaUpdate(const String &url);
+
+TelemetryMessage buildTelemetryMessage(const SensorSnapshot &snapshot) {
+    TelemetryMessage msg{};
+    msg.snapshot = snapshot;
+    msg.timestampMs = static_cast<uint64_t>(esp_timer_get_time() / 1000ULL);
+    msg.success = true;
+    return msg;
+}
+
+void reconfigurePublisher() {
+    if (!configNeedsReinit) {
+        return;
+    }
+    if (publisherMutex) {
+        xSemaphoreTake(publisherMutex, portMAX_DELAY);
+    }
+    publisher = createPublisher(currentConfig.useLoRa);
+    if (publisher) {
+        publisher->setCommandHandler(handleCommand);
+        publisher->begin(currentConfig);
+    }
+    if (publisherMutex) {
+        xSemaphoreGive(publisherMutex);
+    }
+    configNeedsReinit = false;
+}
+
+void performOtaUpdate(const String &url) {
+    if (url.isEmpty()) {
+        return;
+    }
+#ifdef LAB_MODE_WIFI
+    Serial.print("[LAB_MODE][OTA] Requested update from ");
+    Serial.println(url);
+    return;
+#else
+    if (WiFi.status() != WL_CONNECTED) {
+        Serial.println("[OTA] WiFi not connected, aborting");
+        return;
+    }
+    statusLed.setPattern(LedPattern::Ota);
+    WiFiClientSecure client;
+    client.setInsecure();
+    Serial.print("[OTA] Fetching ");
+    Serial.println(url);
+    t_httpUpdate_return ret = httpUpdate.update(client, url);
+    if (ret != HTTP_UPDATE_OK) {
+        Serial.printf("[OTA] Update failed: %s\n", httpUpdate.getLastErrorString().c_str());
+        statusLed.setPattern(LedPattern::Error);
+    } else {
+        Serial.println("[OTA] Update applied, rebooting");
+    }
+#endif
+}
+
+void handleCommand(const String &payload) {
+    StaticJsonDocument<768> doc;
+    const auto err = deserializeJson(doc, payload);
+    if (err != DeserializationError::Ok) {
+        Serial.printf("[CMD] Invalid JSON: %s\n", err.c_str());
+        return;
+    }
+    const String cmd = doc["cmd"].as<String>();
+    if (cmd.equalsIgnoreCase("set_config")) {
+        if (!doc.containsKey("config")) {
+            Serial.println("[CMD] Missing config payload");
+            return;
+        }
+        String configJson;
+        serializeJson(doc["config"], configJson);
+        bool ota = false;
+        if (configManager.updateFromJson(configJson, ota)) {
+            currentConfig = configManager.getConfig();
+            configNeedsReinit = true;
+            Serial.println("[CMD] Configuration updated");
+        }
+        if (ota) {
+            pendingOtaUrl = String(currentConfig.otaUrl);
+            otaRequested = true;
+        }
+    } else if (cmd.equalsIgnoreCase("ota")) {
+        const String url = doc["otaUrl"].as<String>();
+        if (url.length() > 0) {
+            strlcpy(currentConfig.otaUrl, url.c_str(), sizeof(currentConfig.otaUrl));
+            configManager.setConfig(currentConfig);
+            configManager.save();
+            pendingOtaUrl = url;
+            otaRequested = true;
+            Serial.println("[CMD] OTA request stored");
+        }
+    } else if (doc.containsKey("otaUrl")) {
+        const String url = doc["otaUrl"].as<String>();
+        if (url.length() > 0) {
+            strlcpy(currentConfig.otaUrl, url.c_str(), sizeof(currentConfig.otaUrl));
+            configManager.setConfig(currentConfig);
+            configManager.save();
+            pendingOtaUrl = url;
+            otaRequested = true;
+            Serial.println("[CMD] OTA URL received");
+        }
+    } else {
+        Serial.print("[CMD] Unknown command: ");
+        Serial.println(cmd);
+    }
+}
+
+void requestSample() {
+    if (sensingTaskHandle) {
+        xTaskNotifyGive(sensingTaskHandle);
+    }
+}
+
+void sensingTask(void *param) {
+    (void)param;
+    SensorSnapshot snapshot{};
+    for (;;) {
+        ulTaskNotifyTake(pdTRUE, portMAX_DELAY);
+        SoilMoistureData soilMoisture{};
+        TemperatureData soilTemp{};
+        AmbientClimateData ambient{};
+        LightData light{};
+        BatteryData battery{};
+
+        bool success = true;
+        success &= soilMoistureSensor.read(soilMoisture);
+        success &= soilTemperatureSensor.read(soilTemp);
+        success &= ambientSensor.read(ambient);
+        success &= lightSensor.read(light);
+        success &= batteryMonitor.read(battery);
+
+        snapshot.soilMoisture = soilMoisture;
+        snapshot.soilTemperature = soilTemp;
+        snapshot.ambient = ambient;
+        snapshot.light = light;
+        snapshot.battery = battery;
+
+        latestMessage = buildTelemetryMessage(snapshot);
+        latestMessage.success = success;
+
+        if (telemetryQueue) {
+            xQueueOverwrite(telemetryQueue, &latestMessage);
+        }
+        xEventGroupSetBits(systemEvents, EVENT_SAMPLE_READY);
+    }
+}
+
+void uplinkTask(void *param) {
+    (void)param;
+    for (;;) {
+        if (publisherMutex) {
+            if (xSemaphoreTake(publisherMutex, pdMS_TO_TICKS(200)) == pdPASS) {
+                if (publisher) {
+                    publisher->loop();
+                }
+                xSemaphoreGive(publisherMutex);
+            }
+        }
+        EventBits_t bits = xEventGroupWaitBits(systemEvents, EVENT_SAMPLE_READY, pdTRUE, pdFALSE, pdMS_TO_TICKS(500));
+        if ((bits & EVENT_SAMPLE_READY) == 0) {
+            continue;
+        }
+        TelemetryMessage message{};
+        if (telemetryQueue && xQueueReceive(telemetryQueue, &message, 0) != pdPASS) {
+            continue;
+        }
+
+        TelemetryData data{
+            .version = VERSION,
+            .orgId = std::string(currentConfig.orgId),
+            .siteId = std::string(currentConfig.siteId),
+            .nodeId = std::string(currentConfig.nodeId),
+            .timestampMs = message.timestampMs,
+            .soilMoisture = message.snapshot.soilMoisture.normalized,
+            .soilTemperatureC = message.snapshot.soilTemperature.temperatureC,
+            .ambientTemperatureC = message.snapshot.ambient.temperatureC,
+            .ambientHumidity = message.snapshot.ambient.humidity,
+            .lightLux = message.snapshot.light.lux,
+            .batteryVoltage = message.snapshot.battery.voltage,
+        };
+
+        std::string payload = buildTelemetryJson(data);
+        bool published = false;
+        if (publisherMutex) {
+            xSemaphoreTake(publisherMutex, portMAX_DELAY);
+            if (publisher) {
+                published = publisher->publish(payload);
+            }
+            xSemaphoreGive(publisherMutex);
+        }
+        if (published) {
+            Serial.print("[Uplink] Published telemetry: ");
+            Serial.println(payload.c_str());
+            statusLed.setPattern(LedPattern::Ok);
+        } else {
+            Serial.println("[Uplink] Publish failed");
+            statusLed.setPattern(LedPattern::Error);
+        }
+
+        xEventGroupSetBits(systemEvents, EVENT_UPLINK_COMPLETE);
+    }
+}
+
+void powerTask(void *param) {
+    (void)param;
+    requestSample();
+    for (;;) {
+        EventBits_t bits = xEventGroupWaitBits(systemEvents, EVENT_UPLINK_COMPLETE, pdTRUE, pdFALSE, portMAX_DELAY);
+        if ((bits & EVENT_UPLINK_COMPLETE) == 0) {
+            continue;
+        }
+        if (configNeedsReinit) {
+            reconfigurePublisher();
+        }
+        if (otaRequested) {
+            if (!currentConfig.useLoRa) {
+                performOtaUpdate(pendingOtaUrl);
+            } else {
+                Serial.println("[Power] OTA requested but node is in LoRa mode; connect Wi-Fi to update");
+            }
+            otaRequested = false;
+        }
+#ifdef LAB_MODE
+        const uint32_t delayMs = currentConfig.publishIntervalSeconds * 1000U;
+        vTaskDelay(pdMS_TO_TICKS(delayMs));
+        requestSample();
+#else
+        if (currentConfig.sleepStrategy == SleepStrategy::StayAwake) {
+            const uint32_t delayMs = currentConfig.publishIntervalSeconds * 1000U;
+            vTaskDelay(pdMS_TO_TICKS(delayMs));
+            requestSample();
+        } else {
+            Serial.println("[Power] Entering deep sleep");
+            statusLed.setPattern(LedPattern::Off);
+            esp_sleep_enable_timer_wakeup(static_cast<uint64_t>(currentConfig.publishIntervalSeconds) * 1000000ULL);
+            vTaskDelay(pdMS_TO_TICKS(100));
+            esp_deep_sleep_start();
+        }
+#endif
+    }
+}
+
+void setup() {
+    Serial.begin(115200);
+    delay(200);
+    Serial.println();
+    Serial.println("VineGuard ESP32 Node starting");
+
+    statusLed.begin();
+    statusLed.setPattern(LedPattern::Ok);
+
+    if (!configManager.begin()) {
+        Serial.println("[Config] Failed to init NVS");
+    }
+    currentConfig = configManager.getConfig();
+    Serial.print("[Config] Loaded publish interval: ");
+    Serial.println(currentConfig.publishIntervalSeconds);
+
+    if (!soilMoistureSensor.begin()) {
+        Serial.println("[Sensor] Soil moisture init failed");
+    }
+    if (!soilTemperatureSensor.begin()) {
+        Serial.println("[Sensor] Soil temperature init failed");
+    }
+    if (!ambientSensor.begin()) {
+        Serial.println("[Sensor] Ambient sensor init failed");
+    }
+    if (!lightSensor.begin()) {
+        Serial.println("[Sensor] Light sensor init failed");
+    }
+    if (!batteryMonitor.begin()) {
+        Serial.println("[Sensor] Battery monitor init failed");
+    }
+
+    telemetryQueue = xQueueCreate(1, sizeof(TelemetryMessage));
+    systemEvents = xEventGroupCreate();
+    publisherMutex = xSemaphoreCreateMutex();
+
+    publisher = createPublisher(currentConfig.useLoRa);
+    if (publisher) {
+        publisher->setCommandHandler(handleCommand);
+        publisher->begin(currentConfig);
+    }
+
+    xTaskCreatePinnedToCore(sensingTask, "sensing", 4096, nullptr, 2, &sensingTaskHandle, 1);
+    xTaskCreatePinnedToCore(uplinkTask, "uplink", 6144, nullptr, 1, &uplinkTaskHandle, 1);
+    xTaskCreatePinnedToCore(powerTask, "power", 4096, nullptr, 1, &powerTaskHandle, 0);
+
+    Serial.println("[Setup] Tasks started");
+}
+
+void loop() {
+    statusLed.update();
+    delay(50);
+}

--- a/firmware/esp32-node/test/test_helpers/test_main.cpp
+++ b/firmware/esp32-node/test/test_helpers/test_main.cpp
@@ -1,0 +1,58 @@
+#include <ArduinoJson.h>
+#include <cassert>
+#include <cmath>
+#include <string>
+
+#include "SensorMath.h"
+#include "TelemetryBuilder.h"
+
+static bool nearlyEqual(float a, float b, float epsilon = 0.001f) {
+    return std::fabs(a - b) <= epsilon;
+}
+
+int main() {
+    // normalizeSensorReading tests
+    assert(nearlyEqual(normalizeSensorReading(0, 0, 4095), 0.0f));
+    assert(nearlyEqual(normalizeSensorReading(4095, 0, 4095), 1.0f));
+    assert(nearlyEqual(normalizeSensorReading(2048, 0, 4095), 0.5f, 0.01f));
+    assert(nearlyEqual(normalizeSensorReading(2048, 3000, 1000), 0.5f, 0.01f));
+    assert(nearlyEqual(normalizeSensorReading(5000, 0, 4095), 1.0f));
+
+    const float voltage = computeBatteryVoltage(2048, 4095, 3.3f, 100000.0f, 10000.0f);
+    assert(nearlyEqual(voltage, 6.63f, 0.1f));
+
+    TelemetryData data{
+        .version = "0.1.0",
+        .orgId = "org",
+        .siteId = "site",
+        .nodeId = "node",
+        .timestampMs = 123456789ULL,
+        .soilMoisture = 0.42f,
+        .soilTemperatureC = 19.5f,
+        .ambientTemperatureC = 21.1f,
+        .ambientHumidity = 56.0f,
+        .lightLux = 123.4f,
+        .batteryVoltage = 3.71f,
+    };
+
+    std::string json = buildTelemetryJson(data);
+
+    StaticJsonDocument<512> doc;
+    auto err = deserializeJson(doc, json);
+    assert(err == DeserializationError::Ok);
+    assert(std::string(doc["version"]) == "0.1.0");
+    assert(std::string(doc["org"]) == "org");
+    assert(std::string(doc["site"]) == "site");
+    assert(std::string(doc["node"]) == "node");
+    assert(doc["ts"].as<uint64_t>() == 123456789ULL);
+
+    JsonObject meas = doc["measurements"];
+    assert(nearlyEqual(meas["soilMoisture"].as<float>(), 0.42f, 0.001f));
+    assert(nearlyEqual(meas["soilTempC"].as<float>(), 19.5f, 0.001f));
+    assert(nearlyEqual(meas["ambientTempC"].as<float>(), 21.1f, 0.001f));
+    assert(nearlyEqual(meas["ambientHumidity"].as<float>(), 56.0f, 0.001f));
+    assert(nearlyEqual(meas["lightLux"].as<float>(), 123.4f, 0.001f));
+    assert(nearlyEqual(meas["batteryVoltage"].as<float>(), 3.71f, 0.001f));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a PlatformIO-based ESP32 node firmware with FreeRTOS tasks, sensor mocks, telemetry JSON builder, and config persistence
- implement transport abstraction for LoRa or lab Wi-Fi MQTT with command handling and OTA triggering
- document the project layout and provide lab configuration scaffolding plus helper unit tests

## Testing
- :x: `pio run -d firmware/esp32-node` *(unable to install PlatformIO in the sandbox due to outbound network restrictions)*
- :x: `pio test -e native -d firmware/esp32-node` *(unable to install PlatformIO in the sandbox due to outbound network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68cb0b2062948322a3247e3a1db84824