### PR TITLE
feat: add edge gateway prototype

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,28 @@
+# Gateway identity
+GATEWAY_ID=vineguard-gateway-dev
+
+# MQTT broker configuration
+MQTT_HOST=mqtt
+MQTT_PORT=1883
+MQTT_USERNAME=
+MQTT_PASSWORD=
+MQTT_USE_TLS=false
+# Provide the CA certificate path when TLS is enabled
+# MQTT_CA_CERT=/etc/ssl/certs/ca.crt
+# MQTT_CLIENT_CERT=/etc/ssl/certs/client.crt
+# MQTT_CLIENT_KEY=/etc/ssl/private/client.key
+MQTT_TLS_INSECURE=false
+
+# Persistent queue storage
+QUEUE_DB_PATH=/data/gateway_queue.db
+
+# Source configuration
+ENABLE_UDP_SOURCE=true
+UDP_LISTEN_HOST=0.0.0.0
+UDP_LISTEN_PORT=1700
+ENABLE_LORA_SOURCE=true
+LORA_FORCE_SIMULATION=true
+
+# Observability
+HEALTH_PORT=8080
+LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+.venv/
+.env
+edge/gateway/data/*.db
+.edge/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,131 @@
-# VineGuard-Prototype
+# VineGuard Edge Gateway Prototype
+
+This repository contains a Python 3.11 edge gateway that bridges VineGuard LoRa nodes and lab simulators to a cloud MQTT broker. The gateway normalises telemetry, enriches it with gateway metadata, buffers telemetry locally when MQTT is unavailable, and exposes observability endpoints for operations.
+
+## Features
+
+- LoRa (SPI) ingress with automatic simulation fallback when hardware drivers are unavailable.
+- UDP JSON ingress for lab testing and CI workflows.
+- Strategy-based input sources so transports can be extended independently.
+- Disk-backed telemetry queue (SQLite) to survive restarts and publish data when the MQTT broker becomes reachable again.
+- MQTT publishing over TLS with configuration supplied via environment variables.
+- Downlink command subscription on `vineguard/{orgId}/{siteId}/{nodeId}/cmd` and routing back to the original transport.
+- Structured JSON logs and a `/healthz` endpoint for observability.
+- Docker and Docker Compose definitions for local development alongside an EMQX/Mosquitto-compatible broker.
+
+## Repository Layout
+
+```
+edge/
+  gateway/
+    __main__.py         # Application entry point
+    config.py           # Environment driven configuration
+    gateway.py          # Core orchestration between sources and MQTT
+    health.py           # /healthz endpoint using aiohttp
+    logging_config.py   # Structured logging utilities
+    mqtt_client.py      # MQTT client wrapper
+    queue_store.py      # SQLite backed persistent queue
+    telemetry_validator.py # Telemetry schema validation
+    sources/
+      base.py           # Strategy base class
+      lora.py           # LoRa source with simulation fallback
+      udp.py            # UDP JSON source for lab testing
+simulate_node.py        # Helper script to emit UDP telemetry
+requirements.txt
+```
+
+## Getting Started
+
+### Prerequisites
+
+- Python 3.11+
+- `pip`
+- (Optional) Docker and Docker Compose for containerised workflows.
+
+### Local Python Execution
+
+1. Create and populate an environment file:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+   Adjust the values as needed. For local testing with the included Mosquitto broker you can keep TLS disabled.
+
+2. Install dependencies and run the gateway:
+
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   export $(grep -v '^#' .env | xargs)
+   python -m edge.gateway
+   ```
+
+3. In a second terminal, simulate node traffic:
+
+   ```bash
+   python simulate_node.py --host 127.0.0.1 --port 1700 --interval 3
+   ```
+
+   The gateway will validate and enrich the telemetry before publishing it to the configured MQTT broker.
+
+### Docker Compose
+
+The repository includes a compose stack that runs the gateway alongside a Mosquitto broker suitable for development.
+
+```bash
+docker compose up --build
+```
+
+The gateway container exposes:
+
+- UDP listener on port `1700`
+- `/healthz` on port `8080`
+
+To send test data while the stack is running:
+
+```bash
+python simulate_node.py --host 127.0.0.1 --port 1700 --interval 5
+```
+
+### Environment Variables
+
+Key settings consumed by the gateway:
+
+| Variable | Description |
+| --- | --- |
+| `GATEWAY_ID` | Unique identifier for the gateway appended to telemetry records. |
+| `MQTT_HOST` / `MQTT_PORT` | Cloud MQTT endpoint. Compose overrides `MQTT_HOST` to the in-stack broker. |
+| `MQTT_USERNAME` / `MQTT_PASSWORD` | Optional credentials. |
+| `MQTT_USE_TLS` | Enable TLS (`true`/`false`). When enabled provide `MQTT_CA_CERT` and optional client certificate/key paths. |
+| `MQTT_BACKOFF_BASE`, `MQTT_BACKOFF_MAX` | Exponential backoff window used when reconnecting to MQTT. |
+| `QUEUE_DB_PATH` | Filesystem path for the SQLite-backed retry queue. |
+| `ENABLE_UDP_SOURCE` / `ENABLE_LORA_SOURCE` | Toggle ingress sources on or off. |
+| `LORA_FORCE_SIMULATION` | Force the LoRa strategy to use the built-in simulator. |
+| `UDP_LISTEN_HOST` / `UDP_LISTEN_PORT` | UDP binding information. |
+| `HEALTH_PORT` | Port that exposes the `/healthz` endpoint. |
+| `LOG_LEVEL` | Logging verbosity (`INFO`, `DEBUG`, etc.). |
+
+### Health & Observability
+
+- Health endpoint: `http://localhost:8080/healthz`
+- Logs: JSON formatted on stdout, containing metadata for each event.
+
+### Offline Buffering Behaviour
+
+When the MQTT broker is unavailable, telemetry messages are persisted to the SQLite queue at `QUEUE_DB_PATH`. Once connectivity is restored the gateway automatically flushes the backlog using the configured exponential backoff parameters. The queue survives restarts, ensuring telemetry continuity.
+
+### Simulated LoRa Source
+
+When LoRa hardware or drivers are unavailable the gateway falls back to a deterministic simulator that periodically emits sample telemetry. Disable the LoRa simulator by setting `ENABLE_LORA_SOURCE=false` or configure `LORA_FORCE_SIMULATION=false` if real hardware is expected.
+
+## Development Tips
+
+- Adjust the `.env` file to point at your cloud MQTT endpoint and CA certificates when testing TLS.
+- The retry queue directory is mounted into the Docker container at `/data` so messages persist across restarts.
+- Use the `simulate_node.py` utility to generate deterministic traffic during integration testing.
+
+## License
+
+This prototype is provided for demonstration purposes.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.9"
+
+services:
+  mqtt:
+    image: eclipse-mosquitto:2
+    container_name: vineguard-mqtt
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./docker/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
+      - mosquitto-data:/mosquitto/data
+      - mosquitto-logs:/mosquitto/log
+    restart: unless-stopped
+
+  gateway:
+    build:
+      context: .
+      dockerfile: docker/Dockerfile
+    container_name: vineguard-gateway
+    env_file:
+      - .env
+    environment:
+      - MQTT_HOST=mqtt
+    volumes:
+      - ./edge/gateway/data:/data
+    depends_on:
+      - mqtt
+    ports:
+      - "8080:8080"
+    restart: unless-stopped
+
+volumes:
+  mosquitto-data:
+  mosquitto-logs:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY edge ./edge
+COPY simulate_node.py ./simulate_node.py
+
+CMD ["python", "-m", "edge.gateway"]

--- a/docker/mosquitto.conf
+++ b/docker/mosquitto.conf
@@ -1,0 +1,4 @@
+listener 1883 0.0.0.0
+allow_anonymous true
+persistence true
+persistence_location /mosquitto/data/

--- a/edge/gateway/__main__.py
+++ b/edge/gateway/__main__.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+"""Entry point for the VineGuard edge gateway."""
+
+import asyncio
+import signal
+from contextlib import suppress
+
+from .config import Config
+from .gateway import Gateway
+from .health import HealthServer
+from .logging_config import configure_logging
+from .mqtt_client import CloudMqttClient
+from .queue_store import PersistentQueue
+
+
+def _create_gateway(config: Config, queue: PersistentQueue, loop: asyncio.AbstractEventLoop) -> Gateway:
+    gateway_ref: dict[str, Gateway] = {}
+
+    def on_command(topic: str, payload: bytes) -> None:
+        gateway = gateway_ref.get('gateway')
+        if gateway is not None:
+            gateway.handle_command(topic, payload)
+
+    mqtt_client = CloudMqttClient(config, on_command)
+    gateway = Gateway(config=config, queue=queue, mqtt_client=mqtt_client, loop=loop)
+    gateway_ref['gateway'] = gateway
+    return gateway
+
+
+async def _run() -> None:
+    config = Config.from_env()
+    configure_logging(config.log_level)
+
+    queue = PersistentQueue(config.queue_db_path)
+    loop = asyncio.get_running_loop()
+    gateway = _create_gateway(config, queue, loop)
+    health = HealthServer(config, gateway)
+
+    stop_event = asyncio.Event()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        with suppress(NotImplementedError):
+            loop.add_signal_handler(sig, stop_event.set)
+
+    gateway.mqtt.start()
+    await gateway.start_sources()
+    await health.start()
+
+    try:
+        await stop_event.wait()
+    finally:
+        await gateway.stop_sources()
+        await health.stop()
+        gateway.mqtt.stop()
+        queue.close()
+
+
+def main() -> None:
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()

--- a/edge/gateway/config.py
+++ b/edge/gateway/config.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+"""Configuration loading for the VineGuard edge gateway."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+import os
+
+
+@dataclass(slots=True)
+class Config:
+    """Gateway runtime configuration loaded from environment variables."""
+
+    gateway_id: str
+    mqtt_host: str
+    mqtt_port: int
+    mqtt_username: Optional[str]
+    mqtt_password: Optional[str]
+    mqtt_use_tls: bool
+    mqtt_ca_cert: Optional[Path]
+    mqtt_client_cert: Optional[Path]
+    mqtt_client_key: Optional[Path]
+    mqtt_tls_insecure: bool
+    queue_db_path: Path
+    udp_listen_host: str
+    udp_listen_port: int
+    enable_udp_source: bool
+    enable_lora_source: bool
+    lora_force_simulation: bool
+    health_port: int
+    backoff_base: float
+    backoff_max: float
+    log_level: str
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        env = os.getenv
+
+        def _bool(name: str, default: bool = False) -> bool:
+            value = env(name)
+            if value is None:
+                return default
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+
+        def _path(name: str) -> Optional[Path]:
+            value = env(name)
+            if not value:
+                return None
+            return Path(value)
+
+        queue_path = _path("QUEUE_DB_PATH") or Path(env("QUEUE_STORAGE_DIR", "./edge/gateway/data")) / "gateway_queue.db"
+        queue_path.parent.mkdir(parents=True, exist_ok=True)
+
+        mqtt_ca_cert = _path("MQTT_CA_CERT")
+        mqtt_client_cert = _path("MQTT_CLIENT_CERT")
+        mqtt_client_key = _path("MQTT_CLIENT_KEY")
+
+        return cls(
+            gateway_id=env("GATEWAY_ID", "vineguard-gateway"),
+            mqtt_host=env("MQTT_HOST", "localhost"),
+            mqtt_port=int(env("MQTT_PORT", "8883")),
+            mqtt_username=env("MQTT_USERNAME"),
+            mqtt_password=env("MQTT_PASSWORD"),
+            mqtt_use_tls=_bool("MQTT_USE_TLS", True),
+            mqtt_ca_cert=mqtt_ca_cert,
+            mqtt_client_cert=mqtt_client_cert,
+            mqtt_client_key=mqtt_client_key,
+            mqtt_tls_insecure=_bool("MQTT_TLS_INSECURE", False),
+            queue_db_path=queue_path,
+            udp_listen_host=env("UDP_LISTEN_HOST", "0.0.0.0"),
+            udp_listen_port=int(env("UDP_LISTEN_PORT", "1700")),
+            enable_udp_source=_bool("ENABLE_UDP_SOURCE", True),
+            enable_lora_source=_bool("ENABLE_LORA_SOURCE", True),
+            lora_force_simulation=_bool("LORA_FORCE_SIMULATION", False),
+            health_port=int(env("HEALTH_PORT", "8080")),
+            backoff_base=float(env("MQTT_BACKOFF_BASE", "1.0")),
+            backoff_max=float(env("MQTT_BACKOFF_MAX", "32.0")),
+            log_level=env("LOG_LEVEL", "INFO"),
+        )
+
+
+__all__ = ["Config"]

--- a/edge/gateway/gateway.py
+++ b/edge/gateway/gateway.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+"""Core gateway orchestration logic."""
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Dict, Optional
+
+from .config import Config
+from .mqtt_client import CloudMqttClient
+from .queue_store import PersistentQueue
+from .sources.base import NodeKey, PacketSource
+from .sources.lora import LoRaPacketSource
+from .sources.udp import UDPJsonSource
+from .telemetry_validator import TelemetryValidationError, TelemetryValidator
+
+
+class Gateway:
+    """Coordinates the ingress sources and MQTT egress."""
+
+    def __init__(self, config: Config, queue: PersistentQueue, mqtt_client: CloudMqttClient, loop: asyncio.AbstractEventLoop) -> None:
+        self.config = config
+        self.queue = queue
+        self.mqtt = mqtt_client
+        self.loop = loop
+        self.validator = TelemetryValidator()
+        self.logger = logging.getLogger("gateway.core")
+        self.sources: Dict[str, PacketSource] = {}
+        self.node_sources: Dict[NodeKey, PacketSource] = {}
+        self._flush_lock = asyncio.Lock()
+        self._last_message_at: Optional[datetime] = None
+        self._last_publish_success: Optional[datetime] = None
+        self._mqtt_connected: bool = False
+
+        self.mqtt.add_connection_listener(self._on_mqtt_connection_change)
+        self.mqtt.subscribe("vineguard/+/+/+/cmd")
+
+    async def start_sources(self) -> None:
+        if self.config.enable_udp_source:
+            udp_source = UDPJsonSource(
+                host=self.config.udp_listen_host,
+                port=self.config.udp_listen_port,
+                message_callback=self.handle_message,
+            )
+            self.sources[udp_source.name] = udp_source
+            await udp_source.start()
+
+        if self.config.enable_lora_source:
+            lora_source = LoRaPacketSource(
+                message_callback=self.handle_message,
+                force_simulation=self.config.lora_force_simulation,
+            )
+            self.sources[lora_source.name] = lora_source
+            await lora_source.start()
+
+    async def stop_sources(self) -> None:
+        for source in list(self.sources.values()):
+            try:
+                await source.stop()
+            except Exception:
+                self.logger.exception("Failed to stop source", extra={"source": source.name})
+        self.sources.clear()
+
+    async def handle_message(self, source: PacketSource, payload: Dict, context: Dict) -> None:
+        try:
+            validated = self.validator.validate(payload)
+        except TelemetryValidationError as exc:
+            self.logger.warning(
+                "Dropping telemetry due to validation failure",
+                extra={"error": str(exc), "source": source.name},
+            )
+            return
+
+        ingress_context = dict(context)
+        ingress_context.setdefault('source', source.name)
+
+        enriched = dict(validated)
+        enriched.update(
+            {
+                'gatewayId': self.config.gateway_id,
+                'receivedAt': datetime.now(timezone.utc).isoformat(),
+                'ingress': ingress_context,
+            }
+        )
+        topic = f"vineguard/{validated['orgId']}/{validated['siteId']}/{validated['nodeId']}/telemetry"
+        message = json.dumps(enriched, separators=(",", ":"), sort_keys=True)
+
+        key: NodeKey = (validated["orgId"], validated["siteId"], validated["nodeId"])
+        source.register_node(key, context)
+        self.node_sources[key] = source
+        self._last_message_at = datetime.now(timezone.utc)
+
+        if not self.mqtt.publish(topic, message):
+            self.logger.warning("MQTT offline, queueing telemetry", extra={"topic": topic})
+            self.queue.enqueue(topic, message)
+        else:
+            self._last_publish_success = datetime.now(timezone.utc)
+
+    async def flush_queue(self) -> None:
+        async with self._flush_lock:
+            while self.mqtt.is_connected:
+                batch = self.queue.get_batch()
+                if not batch:
+                    break
+                success_ids = []
+                for item in batch:
+                    if self.mqtt.publish(item.topic, item.payload):
+                        success_ids.append(item.id)
+                    else:
+                        self.logger.warning("Publish failed while flushing queue", extra={"id": item.id})
+                        break
+                if success_ids:
+                    self.queue.remove(success_ids)
+                    self._last_publish_success = datetime.now(timezone.utc)
+                await asyncio.sleep(0)
+
+    def handle_command(self, topic: str, payload: bytes) -> None:
+        parts = topic.split("/")
+        if len(parts) != 5:
+            self.logger.warning("Unexpected command topic", extra={"topic": topic})
+            return
+        _, org_id, site_id, node_id, _ = parts
+        key: NodeKey = (org_id, site_id, node_id)
+        source = self.node_sources.get(key)
+        if not source:
+            self.logger.warning("No known source for command", extra={"topic": topic})
+            return
+        delivered = source.send_downlink(key, payload)
+        if delivered:
+            self.logger.info("Forwarded command to source", extra={"topic": topic, "source": source.name})
+        else:
+            self.logger.warning("Failed to forward command", extra={"topic": topic, "source": source.name})
+
+    def _on_mqtt_connection_change(self, connected: bool) -> None:
+        self.loop.call_soon_threadsafe(self._handle_connection_update, connected)
+
+    def _handle_connection_update(self, connected: bool) -> None:
+        self._mqtt_connected = connected
+        if connected:
+            asyncio.create_task(self.flush_queue())
+
+    def build_health_status(self) -> Dict[str, Optional[str]]:
+        queued = self.queue.count()
+        return {
+            "status": "ok" if self._mqtt_connected else "degraded",
+            "mqttConnected": self._mqtt_connected,
+            "queuedMessages": queued,
+            "lastMessageReceived": self._last_message_at.isoformat() if self._last_message_at else None,
+            "lastPublishSuccess": self._last_publish_success.isoformat() if self._last_publish_success else None,
+        }
+
+
+__all__ = ["Gateway"]

--- a/edge/gateway/health.py
+++ b/edge/gateway/health.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+"""Simple HTTP health endpoint for observability."""
+
+from aiohttp import web
+
+from .config import Config
+from .gateway import Gateway
+
+
+class HealthServer:
+    def __init__(self, config: Config, gateway: Gateway) -> None:
+        self._config = config
+        self._gateway = gateway
+        self._runner: web.AppRunner | None = None
+
+    async def start(self) -> None:
+        app = web.Application()
+        app.add_routes([web.get("/healthz", self._handle_health)])
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, host="0.0.0.0", port=self._config.health_port)
+        await site.start()
+
+    async def stop(self) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+            self._runner = None
+
+    async def _handle_health(self, request: web.Request) -> web.Response:
+        status = self._gateway.build_health_status()
+        return web.json_response(status)
+
+
+__all__ = ["HealthServer"]

--- a/edge/gateway/logging_config.py
+++ b/edge/gateway/logging_config.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+"""Structured logging utilities for the gateway."""
+
+import json
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict
+
+
+class JsonFormatter(logging.Formatter):
+    """A lightweight JSON formatter for structured logs."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: Dict[str, Any] = {
+            "timestamp": datetime.fromtimestamp(record.created, tz=timezone.utc).isoformat(),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exception"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            payload["stack"] = record.stack_info
+        # Merge any structured extras that were provided.
+        for key, value in record.__dict__.items():
+            if key.startswith("_") or key in {
+                "name",
+                "msg",
+                "args",
+                "levelname",
+                "levelno",
+                "pathname",
+                "filename",
+                "module",
+                "exc_info",
+                "exc_text",
+                "stack_info",
+                "lineno",
+                "funcName",
+                "created",
+                "msecs",
+                "relativeCreated",
+                "thread",
+                "threadName",
+                "processName",
+                "process",
+            }:
+                continue
+            payload.setdefault("extra", {})[key] = value
+        return json.dumps(payload, ensure_ascii=False)
+
+
+def configure_logging(level: str = "INFO") -> None:
+    """Configure root logging with the JSON formatter."""
+
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(JsonFormatter())
+    root = logging.getLogger()
+    root.setLevel(level.upper())
+    root.handlers.clear()
+    root.addHandler(handler)
+
+
+__all__ = ["configure_logging"]

--- a/edge/gateway/mqtt_client.py
+++ b/edge/gateway/mqtt_client.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+"""MQTT client abstraction for the gateway."""
+
+import logging
+import threading
+from typing import Callable, List
+
+import paho.mqtt.client as mqtt
+
+from .config import Config
+
+
+class CloudMqttClient:
+    """Wraps paho-mqtt to provide connection tracking and callbacks."""
+
+    def __init__(
+        self,
+        config: Config,
+        on_message: Callable[[str, bytes], None],
+    ) -> None:
+        self._config = config
+        self._on_message = on_message
+        self._client = mqtt.Client(client_id=config.gateway_id, clean_session=False)
+        if config.mqtt_username:
+            self._client.username_pw_set(config.mqtt_username, config.mqtt_password)
+        if config.mqtt_use_tls:
+            self._client.tls_set(
+                ca_certs=str(config.mqtt_ca_cert) if config.mqtt_ca_cert else None,
+                certfile=str(config.mqtt_client_cert) if config.mqtt_client_cert else None,
+                keyfile=str(config.mqtt_client_key) if config.mqtt_client_key else None,
+            )
+            if config.mqtt_tls_insecure:
+                self._client.tls_insecure_set(True)
+        self._client.on_connect = self._handle_connect
+        self._client.on_disconnect = self._handle_disconnect
+        self._client.on_message = self._handle_message
+        self._client.reconnect_delay_set(min_delay=config.backoff_base, max_delay=config.backoff_max)
+        self._connected = threading.Event()
+        self._connection_listeners: List[Callable[[bool], None]] = []
+        self._logger = logging.getLogger("gateway.mqtt")
+        self._lock = threading.Lock()
+
+    def start(self) -> None:
+        self._logger.info(
+            "Connecting to MQTT broker",
+            extra={"host": self._config.mqtt_host, "port": self._config.mqtt_port, "tls": self._config.mqtt_use_tls},
+        )
+        self._client.loop_start()
+        try:
+            self._client.connect(self._config.mqtt_host, self._config.mqtt_port, keepalive=60)
+        except Exception:
+            self._logger.exception("Initial MQTT connection failed")
+
+    def stop(self) -> None:
+        self._client.loop_stop()
+        try:
+            self._client.disconnect()
+        except Exception:
+            self._logger.exception("Error while disconnecting MQTT client")
+
+    def publish(self, topic: str, payload: str, qos: int = 1) -> bool:
+        with self._lock:
+            if not self.is_connected:
+                return False
+            try:
+                result = self._client.publish(topic, payload=payload, qos=qos)
+            except Exception:
+                self._logger.exception("MQTT publish failed", extra={"topic": topic})
+                return False
+        if result.rc != mqtt.MQTT_ERR_SUCCESS:
+            self._logger.warning("MQTT publish returned error", extra={"topic": topic, "rc": result.rc})
+            return False
+        return True
+
+    def subscribe(self, topic: str, qos: int = 1) -> None:
+        try:
+            result, _ = self._client.subscribe(topic, qos=qos)
+        except Exception:
+            self._logger.exception("Failed to subscribe to topic", extra={"topic": topic})
+            return
+        if result == mqtt.MQTT_ERR_SUCCESS:
+            self._logger.info("Subscribed to topic", extra={"topic": topic})
+        else:
+            self._logger.warning("Subscription deferred", extra={"topic": topic, "rc": result})
+
+    def add_connection_listener(self, callback: Callable[[bool], None]) -> None:
+        self._connection_listeners.append(callback)
+
+    @property
+    def is_connected(self) -> bool:
+        return self._connected.is_set()
+
+    def _handle_connect(self, client: mqtt.Client, userdata, flags, rc) -> None:  # type: ignore[override]
+        success = rc == 0
+        if success:
+            self._connected.set()
+            self._logger.info("Connected to MQTT broker")
+        else:
+            self._logger.error("MQTT connection failed", extra={"rc": rc})
+        for callback in self._connection_listeners:
+            try:
+                callback(success)
+            except Exception:
+                self._logger.exception("Connection listener failed")
+
+    def _handle_disconnect(self, client: mqtt.Client, userdata, rc) -> None:  # type: ignore[override]
+        self._connected.clear()
+        self._logger.warning("Disconnected from MQTT broker", extra={"rc": rc})
+        for callback in self._connection_listeners:
+            try:
+                callback(False)
+            except Exception:
+                self._logger.exception("Connection listener failed")
+
+    def _handle_message(self, client: mqtt.Client, userdata, message: mqtt.MQTTMessage) -> None:  # type: ignore[override]
+        try:
+            self._on_message(message.topic, message.payload)
+        except Exception:
+            self._logger.exception("Failed to handle MQTT message", extra={"topic": message.topic})
+
+
+__all__ = ["CloudMqttClient"]

--- a/edge/gateway/queue_store.py
+++ b/edge/gateway/queue_store.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""Disk-backed queue implementation using SQLite for message buffering."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from threading import Lock
+from typing import Iterable, List
+import sqlite3
+import time
+
+
+@dataclass(slots=True)
+class QueueItem:
+    id: int
+    topic: str
+    payload: str
+    created_at: float
+
+
+class PersistentQueue:
+    """A small SQLite-backed persistent queue for MQTT messages."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = Path(path)
+        self._lock = Lock()
+        self._connection = sqlite3.connect(self._path, check_same_thread=False)
+        self._connection.execute(
+            """
+            CREATE TABLE IF NOT EXISTS queued_messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                topic TEXT NOT NULL,
+                payload TEXT NOT NULL,
+                created_at REAL NOT NULL
+            )
+            """
+        )
+        self._connection.commit()
+
+    def enqueue(self, topic: str, payload: str) -> None:
+        with self._lock:
+            self._connection.execute(
+                "INSERT INTO queued_messages (topic, payload, created_at) VALUES (?, ?, ?)",
+                (topic, payload, time.time()),
+            )
+            self._connection.commit()
+
+    def get_batch(self, limit: int = 50) -> List[QueueItem]:
+        with self._lock:
+            cursor = self._connection.execute(
+                "SELECT id, topic, payload, created_at FROM queued_messages ORDER BY id ASC LIMIT ?",
+                (limit,),
+            )
+            rows = [QueueItem(*row) for row in cursor.fetchall()]
+        return rows
+
+    def remove(self, ids: Iterable[int]) -> None:
+        ids_list = list(ids)
+        if not ids_list:
+            return
+        with self._lock:
+            self._connection.executemany("DELETE FROM queued_messages WHERE id = ?", ((i,) for i in ids_list))
+            self._connection.commit()
+
+    def count(self) -> int:
+        with self._lock:
+            cursor = self._connection.execute("SELECT COUNT(1) FROM queued_messages")
+            (count,) = cursor.fetchone()
+        return int(count)
+
+    def close(self) -> None:
+        with self._lock:
+            self._connection.close()
+
+
+__all__ = ["PersistentQueue", "QueueItem"]

--- a/edge/gateway/sources/base.py
+++ b/edge/gateway/sources/base.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+"""Base classes for gateway data sources."""
+
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, Tuple
+
+MessageCallback = Callable[["PacketSource", Dict[str, Any], Dict[str, Any]], Any]
+NodeKey = Tuple[str, str, str]
+
+
+class PacketSource(ABC):
+    """Abstract base class for gateway ingress sources."""
+
+    def __init__(self, name: str, message_callback: MessageCallback) -> None:
+        self.name = name
+        self._message_callback = message_callback
+
+    @abstractmethod
+    async def start(self) -> None:
+        """Start receiving packets."""
+
+    @abstractmethod
+    async def stop(self) -> None:
+        """Stop receiving packets."""
+
+    def register_node(self, node_key: NodeKey, context: Dict[str, Any]) -> None:
+        """Allow sources to persist metadata for a node (no-op by default)."""
+
+    def send_downlink(self, node_key: NodeKey, payload: bytes) -> bool:
+        """Send a downlink payload to the specified node. Returns success."""
+        return False
+
+    async def _dispatch(self, payload: Dict[str, Any], context: Dict[str, Any]) -> None:
+        awaitable = self._message_callback(self, payload, context)
+        if hasattr(awaitable, "__await__"):
+            await awaitable  # type: ignore[func-returns-value]
+
+
+__all__ = ["PacketSource", "NodeKey", "MessageCallback"]

--- a/edge/gateway/sources/lora.py
+++ b/edge/gateway/sources/lora.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+"""LoRa packet source using SPI (with simulation fallback)."""
+
+import asyncio
+import json
+import logging
+import random
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from .base import PacketSource
+
+
+class LoRaPacketSource(PacketSource):
+    """LoRa packet source that falls back to simulation when hardware is absent."""
+
+    def __init__(self, message_callback, force_simulation: bool = False) -> None:
+        super().__init__("lora", message_callback)
+        self.logger = logging.getLogger("gateway.lora")
+        self._force_simulation = force_simulation
+        self._task: Optional[asyncio.Task[None]] = None
+        self._simulated = force_simulation
+        self._hardware = None
+        if not force_simulation:
+            try:
+                from lora import LoRa  # type: ignore
+
+                self._hardware = LoRa()
+                self._simulated = False
+                self.logger.info("Initialized LoRa hardware interface")
+            except Exception as exc:  # pragma: no cover - hardware path
+                self._simulated = True
+                self.logger.warning(
+                    "LoRa hardware unavailable, using simulation",
+                    extra={"error": str(exc)},
+                )
+
+    async def start(self) -> None:
+        if self._simulated:
+            self._task = asyncio.create_task(self._simulation_loop())
+            self.logger.info("LoRa simulation started")
+        else:  # pragma: no cover - hardware path
+            self._task = asyncio.create_task(self._hardware_loop())
+            self.logger.info("LoRa hardware loop started")
+
+    async def stop(self) -> None:
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        if self._hardware:  # pragma: no cover - hardware path
+            try:
+                self._hardware.close()
+            except Exception:
+                self.logger.exception("Failed to close LoRa hardware")
+
+    async def _simulation_loop(self) -> None:
+        nodes = ["lora-node-1", "lora-node-2"]
+        while True:
+            node = random.choice(nodes)
+            payload = {
+                "nodeId": node,
+                "orgId": "sim-org",
+                "siteId": "sim-site",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "metrics": {
+                    "temperature": round(random.uniform(10.0, 32.0), 2),
+                    "humidity": round(random.uniform(40.0, 70.0), 2),
+                },
+            }
+            context: Dict[str, Any] = {
+                "transport": "lora",
+                "rssi": random.randint(-110, -70),
+                "snr": round(random.uniform(-12.0, 5.0), 2),
+                "simulated": True,
+            }
+            await self._dispatch(payload, context)
+            await asyncio.sleep(random.uniform(5.0, 10.0))
+
+    async def _hardware_loop(self) -> None:  # pragma: no cover - hardware path
+        assert self._hardware is not None
+        while True:
+            raw = self._hardware.recv()
+            if not raw:
+                await asyncio.sleep(0.1)
+                continue
+            try:
+                payload = json.loads(raw.decode("utf-8"))
+            except Exception:
+                self.logger.warning("Received invalid LoRa payload", extra={"raw": raw})
+                continue
+            context: Dict[str, Any] = {"transport": "lora", "simulated": False}
+            await self._dispatch(payload, context)
+
+    def send_downlink(self, node_key, payload: bytes) -> bool:
+        if self._simulated:
+            try:
+                decoded = payload.decode("utf-8")
+            except Exception:
+                decoded = str(payload)
+            self.logger.info(
+                "Simulated LoRa downlink", extra={"node": node_key, "payload": decoded}
+            )
+            return True
+        if not self._hardware:  # pragma: no cover - hardware path
+            self.logger.warning("LoRa hardware not initialised for downlink", extra={"node": node_key})
+            return False
+        try:
+            self._hardware.send(payload)
+            self.logger.info("LoRa downlink queued", extra={"node": node_key})
+            return True
+        except Exception:  # pragma: no cover - hardware path
+            self.logger.exception("Failed to send LoRa downlink", extra={"node": node_key})
+            return False
+
+
+__all__ = ["LoRaPacketSource"]

--- a/edge/gateway/sources/udp.py
+++ b/edge/gateway/sources/udp.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+"""UDP JSON packet source for lab testing."""
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from .base import NodeKey, PacketSource
+
+
+class _UDPProtocol(asyncio.DatagramProtocol):
+    def __init__(self, source: "UDPJsonSource") -> None:
+        self._source = source
+
+    def datagram_received(self, data: bytes, addr) -> None:  # type: ignore[override]
+        asyncio.create_task(self._source._handle_datagram(data, addr))
+
+    def error_received(self, exc: Exception) -> None:  # type: ignore[override]
+        self._source.logger.error("UDP error", extra={"error": str(exc)})
+
+
+class UDPJsonSource(PacketSource):
+    """Packet source that consumes JSON payloads over UDP."""
+
+    def __init__(self, host: str, port: int, message_callback) -> None:
+        super().__init__("udp", message_callback)
+        self._host = host
+        self._port = port
+        self._transport: Optional[asyncio.transports.DatagramTransport] = None
+        self._node_addresses: Dict[NodeKey, Any] = {}
+        self.logger = logging.getLogger("gateway.udp")
+
+    async def start(self) -> None:
+        loop = asyncio.get_running_loop()
+        self._transport, _ = await loop.create_datagram_endpoint(
+            lambda: _UDPProtocol(self),
+            local_addr=(self._host, self._port),
+        )
+        self.logger.info("UDP source started", extra={"host": self._host, "port": self._port})
+
+    async def stop(self) -> None:
+        if self._transport is not None:
+            self._transport.close()
+            self._transport = None
+            self.logger.info("UDP source stopped")
+
+    async def _handle_datagram(self, data: bytes, addr) -> None:
+        try:
+            payload = json.loads(data.decode("utf-8"))
+        except json.JSONDecodeError:
+            self.logger.warning("Dropping invalid JSON payload", extra={"remote": addr})
+            return
+        context: Dict[str, Any] = {"transport": "udp", "remote": addr}
+        await self._dispatch(payload, context)
+
+    def register_node(self, node_key: NodeKey, context: Dict[str, Any]) -> None:
+        remote = context.get("remote")
+        if remote:
+            self._node_addresses[node_key] = remote
+
+    def send_downlink(self, node_key: NodeKey, payload: bytes) -> bool:
+        if self._transport is None:
+            self.logger.warning("UDP transport not ready for downlink", extra={"node": node_key})
+            return False
+        remote = self._node_addresses.get(node_key)
+        if not remote:
+            self.logger.warning("No UDP endpoint known for node", extra={"node": node_key})
+            return False
+        self._transport.sendto(payload, remote)
+        self.logger.info("Sent UDP downlink", extra={"node": node_key, "remote": remote})
+        return True
+
+
+__all__ = ["UDPJsonSource"]

--- a/edge/gateway/telemetry_validator.py
+++ b/edge/gateway/telemetry_validator.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+"""Telemetry validation helpers."""
+
+from datetime import datetime
+from typing import Any, Dict
+
+
+class TelemetryValidationError(ValueError):
+    """Raised when telemetry payloads do not match the schema."""
+
+
+class TelemetryValidator:
+    """Validates and normalises telemetry payloads."""
+
+    REQUIRED_STRING_FIELDS = ("nodeId", "orgId", "siteId")
+    TIMESTAMP_FIELD = "timestamp"
+    METRICS_FIELD = "metrics"
+
+    def validate(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if not isinstance(payload, dict):
+            raise TelemetryValidationError("Telemetry payload must be a JSON object")
+
+        for field in self.REQUIRED_STRING_FIELDS:
+            value = payload.get(field)
+            if not isinstance(value, str) or not value.strip():
+                raise TelemetryValidationError(f"Field '{field}' must be a non-empty string")
+
+        timestamp = payload.get(self.TIMESTAMP_FIELD)
+        if not isinstance(timestamp, str) or not timestamp:
+            raise TelemetryValidationError("Telemetry payload must include an ISO8601 'timestamp'")
+        try:
+            datetime.fromisoformat(timestamp.replace("Z", "+00:00"))
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise TelemetryValidationError("Telemetry timestamp is not a valid ISO8601 string") from exc
+
+        metrics = payload.get(self.METRICS_FIELD)
+        if not isinstance(metrics, dict) or not metrics:
+            raise TelemetryValidationError("Telemetry payload must include a non-empty 'metrics' object")
+        for key, value in metrics.items():
+            if not isinstance(key, str) or not key:
+                raise TelemetryValidationError("Metric keys must be non-empty strings")
+            if not isinstance(value, (int, float)):
+                raise TelemetryValidationError(f"Metric '{key}' must be numeric")
+
+        return payload
+
+
+__all__ = ["TelemetryValidator", "TelemetryValidationError"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+aiohttp==3.9.5
+paho-mqtt==1.6.1

--- a/simulate_node.py
+++ b/simulate_node.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+"""Utility script to simulate node telemetry over UDP."""
+
+import argparse
+import json
+import random
+import socket
+import time
+from datetime import datetime, timezone
+
+
+def build_payload(org_id: str, site_id: str, node_id: str) -> dict:
+    return {
+        "orgId": org_id,
+        "siteId": site_id,
+        "nodeId": node_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "metrics": {
+            "temperature": round(random.uniform(18.0, 30.0), 2),
+            "humidity": round(random.uniform(40.0, 65.0), 2),
+            "battery": round(random.uniform(3.4, 4.1), 2),
+        },
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simulate a VineGuard node sending telemetry")
+    parser.add_argument("--host", default="127.0.0.1", help="Gateway UDP host (default: 127.0.0.1)")
+    parser.add_argument("--port", type=int, default=1700, help="Gateway UDP port (default: 1700)")
+    parser.add_argument("--org", default="sim-org", help="Organisation identifier")
+    parser.add_argument("--site", default="sim-site", help="Site identifier")
+    parser.add_argument("--node", default="udp-node-1", help="Node identifier")
+    parser.add_argument("--interval", type=float, default=5.0, help="Interval between packets in seconds")
+    parser.add_argument("--count", type=int, default=0, help="Number of packets to send (0 for infinite)")
+
+    args = parser.parse_args()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    target = (args.host, args.port)
+
+    sent = 0
+    try:
+        while True:
+            payload = build_payload(args.org, args.site, args.node)
+            message = json.dumps(payload).encode("utf-8")
+            sock.sendto(message, target)
+            sent += 1
+            print(f"sent packet {sent} -> {target}: {message.decode('utf-8')}")
+            if args.count and sent >= args.count:
+                break
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        sock.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- implement a Python gateway that validates telemetry, enriches it with gateway metadata, and bridges UDP/LoRa sources to MQTT with disk-backed retries
- add health endpoint, structured logging, environment-driven configuration, and simulator utilities for lab testing
- provide Docker/Docker Compose setup, environment template, and documentation for operating the edge gateway

## Testing
- python -m compileall edge simulate_node.py
- python -m compileall edge/gateway/mqtt_client.py

------
https://chatgpt.com/codex/tasks/task_e_68cb0b275dbc832287a16384e678037c