### PR TITLE
Add Vite-based VineGuard dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules/
+dist/
+.vite/
+.env
+.DS_Store

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=https://api.vineguard.local

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,37 @@
+# VineGuard Web Dashboard
+
+A Vite + React + TypeScript dashboard for monitoring vineyard sensor fleets. The app pairs Tailwind CSS with shadcn/ui primitives and renders telemetry with Recharts.
+
+## Getting started
+
+1. Copy `.env.example` to `.env` and configure the API location:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Install dependencies and launch the development server:
+
+   ```bash
+   npm install
+   npm run dev
+   ```
+
+   The dashboard will be available at `http://localhost:5173`.
+
+## Features
+
+- Email/password authentication with automatic token refresh and a seeded demo fallback.
+- React Router navigation for the organizational overview, site and node detail views, and the insights activity feed.
+- Real-time telemetry via Server-Sent Events with an automatic polling fallback that streams mock data.
+- Reusable UI elements such as metric cards, status pills, and insight badges based on shadcn/ui patterns.
+- Command panel that issues `POST /commands` requests to adjust node publish intervals or stage OTA firmware URLs.
+
+## Tech stack
+
+- [Vite](https://vitejs.dev/) + React + TypeScript
+- [Tailwind CSS](https://tailwindcss.com/) with [shadcn/ui](https://ui.shadcn.com/) component patterns
+- [Recharts](https://recharts.org/) for time-series visualization
+- [React Router](https://reactrouter.com/) for routing
+
+The project ships with deterministic mock data so you can explore the dashboard without a running API. Configure `VITE_API_URL` to connect it to a live backend.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>VineGuard Dashboard</title>
+  </head>
+  <body class="bg-slate-950 text-slate-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "vineguard-web",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "lint": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@radix-ui/react-slot": "^1.0.2",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "lucide-react": "^0.321.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "recharts": "^2.7.2",
+    "tailwindcss-animate": "^1.0.7",
+    "tailwind-merge": "^2.2.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.57",
+    "@types/react-dom": "^18.2.19",
+    "@vitejs/plugin-react": "^4.2.0",
+    "autoprefixer": "^10.4.16",
+    "postcss": "^8.4.35",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.4.2",
+    "vite": "^5.1.0"
+  }
+}

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/web/public/vite.svg
+++ b/web/public/vite.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 410 404" fill="none">
+  <path d="M399.641 59.5258L215.643 388.955C210.556 398.15 197.794 398.15 192.707 388.955L10.3585 59.5258C5.03654 49.8605 12.6782 38 23.6516 38H386.47C397.444 38 405.086 49.8605 399.641 59.5258Z" fill="url(#paint0_linear)"/>
+  <path d="M292.965 1.5744L156.857 282.983C154.94 287.008 149.121 287.008 147.204 282.983L114.239 214.815L32.5463 54.0772C28.8926 46.9482 34.3536 38 42.2787 38H166.139L225.531 1.5744C229.451 -0.524799 234.134 -0.5248 238.054 1.5744L292.965 33.9659V1.5744Z" fill="url(#paint1_linear)"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="6.00017" y1="32.9999" x2="235" y2="344" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#41D1FF"/>
+      <stop offset="1" stop-color="#BD34FE"/>
+    </linearGradient>
+    <linearGradient id="paint1_linear" x1="194.651" y1="8.81818" x2="236.076" y2="292.989" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#FFEA83"/>
+      <stop offset="0.0833333" stop-color="#FFDD35"/>
+      <stop offset="1" stop-color="#FFA800"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,0 +1,65 @@
+import { Suspense } from 'react';
+import { Navigate, Outlet, Route, Routes } from 'react-router-dom';
+import DashboardLayout from '@/components/layout/DashboardLayout';
+import { useAuth } from '@/hooks/useAuth';
+import LoginPage from '@/pages/Auth/LoginPage';
+import RegisterPage from '@/pages/Auth/RegisterPage';
+import OverviewPage from '@/pages/Dashboard/OverviewPage';
+import SiteDetailPage from '@/pages/Sites/SiteDetailPage';
+import NodeDetailPage from '@/pages/Nodes/NodeDetailPage';
+import InsightsPage from '@/pages/Insights/InsightsPage';
+import LoadingScreen from '@/components/shared/LoadingScreen';
+
+const ProtectedRoute = () => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <LoadingScreen />;
+  }
+
+  if (!user) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <Outlet />;
+};
+
+const PublicOnlyRoute = () => {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return <LoadingScreen />;
+  }
+
+  if (user) {
+    return <Navigate to="/" replace />;
+  }
+
+  return <Outlet />;
+};
+
+function App() {
+  return (
+    <Suspense fallback={<LoadingScreen />}>
+      <Routes>
+        <Route element={<PublicOnlyRoute />}>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<RegisterPage />} />
+        </Route>
+
+        <Route element={<ProtectedRoute />}>
+          <Route element={<DashboardLayout />}>
+            <Route index element={<OverviewPage />} />
+            <Route path="sites/:siteId" element={<SiteDetailPage />} />
+            <Route path="nodes/:nodeId" element={<NodeDetailPage />} />
+            <Route path="insights" element={<InsightsPage />} />
+          </Route>
+        </Route>
+
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
+    </Suspense>
+  );
+}
+
+export default App;

--- a/web/src/components/charts/TimeSeriesChart.tsx
+++ b/web/src/components/charts/TimeSeriesChart.tsx
@@ -1,0 +1,103 @@
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { NodeTelemetryPoint } from '@/types';
+import { formatDateTime } from '@/utils';
+
+interface SeriesDefinition {
+  dataKey: keyof NodeTelemetryPoint;
+  name: string;
+  color: string;
+  unit?: string;
+  type?: 'monotone' | 'linear';
+}
+
+interface TimeSeriesChartProps {
+  title: string;
+  data: NodeTelemetryPoint[];
+  series: SeriesDefinition[];
+  height?: number;
+  variant?: 'line' | 'area';
+}
+
+const TimeSeriesChart = ({ title, data, series, height = 280, variant = 'area' }: TimeSeriesChartProps) => {
+  const ChartComponent = variant === 'line' ? LineChart : AreaChart;
+
+  return (
+    <Card className="border-border/40 bg-slate-900/50">
+      <CardHeader>
+        <CardTitle className="text-base font-semibold text-foreground">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="h-full w-full">
+        <div className="h-[280px] w-full">
+          <ResponsiveContainer width="100%" height={height}>
+            <ChartComponent data={data} margin={{ left: 0, right: 12, top: 16, bottom: 0 }}>
+              <defs>
+                {series.map((serie) => (
+                  <linearGradient id={`${String(serie.dataKey)}Gradient`} key={serie.dataKey} x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor={serie.color} stopOpacity={0.4} />
+                    <stop offset="100%" stopColor={serie.color} stopOpacity={0.05} />
+                  </linearGradient>
+                ))}
+              </defs>
+              <CartesianGrid strokeDasharray="3 3" stroke="rgba(148, 163, 184, 0.2)" />
+              <XAxis
+                dataKey="timestamp"
+                stroke="rgba(148,163,184,0.6)"
+                tickFormatter={(value) => formatDateTime(value)}
+                minTickGap={24}
+              />
+              <YAxis stroke="rgba(148,163,184,0.6)" />
+              <Tooltip
+                contentStyle={{
+                  background: 'rgba(15, 23, 42, 0.95)',
+                  borderRadius: 12,
+                  border: '1px solid rgba(148, 163, 184, 0.2)'
+                }}
+                labelFormatter={(value) => formatDateTime(value)}
+              />
+              <Legend wrapperStyle={{ color: 'rgba(226, 232, 240, 0.6)' }} />
+              {series.map((serie) =>
+                variant === 'line' ? (
+                  <Line
+                    type={serie.type ?? 'monotone'}
+                    key={serie.dataKey}
+                    dataKey={serie.dataKey}
+                    name={serie.name}
+                    stroke={serie.color}
+                    strokeWidth={2}
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                ) : (
+                  <Area
+                    type={serie.type ?? 'monotone'}
+                    key={serie.dataKey}
+                    dataKey={serie.dataKey}
+                    name={serie.name}
+                    stroke={serie.color}
+                    fill={`url(#${String(serie.dataKey)}Gradient)`}
+                    strokeWidth={2}
+                    isAnimationActive={false}
+                  />
+                )
+              )}
+            </ChartComponent>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default TimeSeriesChart;

--- a/web/src/components/layout/DashboardLayout.tsx
+++ b/web/src/components/layout/DashboardLayout.tsx
@@ -1,0 +1,141 @@
+import { Link, NavLink, Outlet, useLocation } from 'react-router-dom';
+import { useMemo, useState } from 'react';
+import { Menu, Power, Sprout } from 'lucide-react';
+import { useAuth } from '@/hooks/useAuth';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/utils';
+
+const navigation = [
+  { to: '/', label: 'Overview' },
+  { to: '/insights', label: 'Insights' }
+];
+
+const DashboardLayout = () => {
+  const { user, logout } = useAuth();
+  const location = useLocation();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  const activeNav = useMemo(() => {
+    if (location.pathname.startsWith('/sites')) return '/sites';
+    if (location.pathname.startsWith('/nodes')) return '/nodes';
+    return navigation.find((nav) => nav.to === location.pathname)?.to ?? '/';
+  }, [location.pathname]);
+
+  return (
+    <div className="flex min-h-screen bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 text-slate-100">
+      <aside
+        className={cn(
+          'fixed inset-y-0 left-0 z-40 flex w-64 flex-col border-r border-border/50 bg-slate-900/70 p-6 shadow-2xl backdrop-blur-lg transition-transform lg:static lg:translate-x-0',
+          mobileOpen ? 'translate-x-0' : '-translate-x-full lg:translate-x-0'
+        )}
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-primary/20 text-primary">
+            <Sprout className="h-6 w-6" />
+          </div>
+          <div>
+            <p className="text-lg font-semibold">VineGuard</p>
+            <p className="text-xs text-muted-foreground">Smart viticulture control</p>
+          </div>
+        </div>
+
+        <nav className="mt-10 space-y-2">
+          {navigation.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                cn(
+                  'flex items-center rounded-lg px-3 py-2 text-sm font-medium transition',
+                  isActive || activeNav === item.to
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:bg-slate-800/60 hover:text-foreground'
+                )
+              }
+              onClick={() => setMobileOpen(false)}
+            >
+              {item.label}
+            </NavLink>
+          ))}
+          <NavLink
+            to="/sites/demo-vineyard"
+            className={({ isActive }) =>
+              cn(
+                'flex items-center rounded-lg px-3 py-2 text-sm font-medium transition',
+                isActive || activeNav === '/sites'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:bg-slate-800/60 hover:text-foreground'
+              )
+            }
+            onClick={() => setMobileOpen(false)}
+          >
+            Sites
+          </NavLink>
+          <NavLink
+            to="/nodes/alpha"
+            className={({ isActive }) =>
+              cn(
+                'flex items-center rounded-lg px-3 py-2 text-sm font-medium transition',
+                isActive || activeNav === '/nodes'
+                  ? 'bg-primary/10 text-primary'
+                  : 'text-muted-foreground hover:bg-slate-800/60 hover:text-foreground'
+              )
+            }
+            onClick={() => setMobileOpen(false)}
+          >
+            Nodes
+          </NavLink>
+        </nav>
+
+        <div className="mt-auto flex flex-col gap-3 rounded-lg border border-border/40 bg-slate-950/50 p-4 text-xs text-muted-foreground">
+          <p className="text-sm font-semibold text-foreground">{user?.name ?? user?.email}</p>
+          <p>{user?.orgId ? `Org: ${user.orgId}` : 'Demo organization'}</p>
+          <Button variant="ghost" className="mt-2 justify-start gap-2 text-sm" onClick={logout}>
+            <Power className="h-4 w-4" /> Sign out
+          </Button>
+        </div>
+      </aside>
+
+      <div className="flex flex-1 flex-col lg:ml-64">
+        <header className="flex items-center justify-between border-b border-border/50 bg-slate-900/60 px-6 py-4 backdrop-blur">
+          <div className="flex items-center gap-3">
+            <Button
+              variant="ghost"
+              className="lg:hidden"
+              size="icon"
+              onClick={() => setMobileOpen((prev) => !prev)}
+            >
+              <Menu className="h-5 w-5" />
+            </Button>
+            <div>
+              <p className="text-xl font-semibold">Operational Dashboard</p>
+              <p className="text-sm text-muted-foreground">
+                Monitor vineyard health, telemetry and commands in real time.
+              </p>
+            </div>
+          </div>
+
+          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+            <div className="hidden sm:flex flex-col text-right">
+              <span className="text-sm font-medium text-foreground">{user?.name ?? 'Demo Grower'}</span>
+              <span>{user?.email}</span>
+            </div>
+            <Link
+              to="https://docs.vineguard.local"
+              target="_blank"
+              className="rounded-full border border-primary/40 px-4 py-1 text-xs font-medium text-primary hover:bg-primary/10"
+            >
+              View docs
+            </Link>
+          </div>
+        </header>
+
+        <main className="flex-1 space-y-6 px-4 py-6 sm:px-6 lg:px-10">
+          <Outlet />
+        </main>
+      </div>
+    </div>
+  );
+};
+
+export default DashboardLayout;

--- a/web/src/components/shared/InsightBadge.tsx
+++ b/web/src/components/shared/InsightBadge.tsx
@@ -1,0 +1,33 @@
+import { Badge } from '@/components/ui/badge';
+import type { Insight, InsightType } from '@/types';
+
+const typeToVariant: Record<InsightType, 'default' | 'secondary' | 'destructive'> = {
+  irrigation: 'default',
+  disease: 'destructive',
+  battery: 'secondary'
+};
+
+const severityTone: Record<Insight['severity'], string> = {
+  low: 'bg-emerald-500/20 text-emerald-300',
+  medium: 'bg-amber-500/20 text-amber-300',
+  high: 'bg-rose-500/20 text-rose-300'
+};
+
+interface InsightBadgeProps {
+  type: InsightType;
+  severity: Insight['severity'];
+  className?: string;
+}
+
+const InsightBadge = ({ type, severity, className }: InsightBadgeProps) => {
+  return (
+    <Badge
+      variant={typeToVariant[type]}
+      className={`${severityTone[severity]} border-transparent capitalize ${className ?? ''}`.trim()}
+    >
+      {type} · {severity}
+    </Badge>
+  );
+};
+
+export default InsightBadge;

--- a/web/src/components/shared/LoadingScreen.tsx
+++ b/web/src/components/shared/LoadingScreen.tsx
@@ -1,0 +1,12 @@
+const LoadingScreen = () => {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-200">
+      <div className="flex flex-col items-center gap-4">
+        <div className="h-12 w-12 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+        <p className="text-sm text-muted-foreground">Loading VineGuard...</p>
+      </div>
+    </div>
+  );
+};
+
+export default LoadingScreen;

--- a/web/src/components/shared/MetricCard.tsx
+++ b/web/src/components/shared/MetricCard.tsx
@@ -1,0 +1,53 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { cn, formatPercentage } from '@/utils';
+import type { ReactNode } from 'react';
+
+interface MetricCardProps {
+  title: string;
+  value: number | string;
+  subtitle?: string;
+  icon?: ReactNode;
+  trend?: {
+    label: string;
+    value: number;
+    isPositive?: boolean;
+  };
+  format?: (value: number | string) => string;
+}
+
+const MetricCard = ({ title, value, subtitle, icon, trend, format }: MetricCardProps) => {
+  const renderValue = () => {
+    if (typeof value === 'number') {
+      return format ? format(value) : value.toLocaleString();
+    }
+    return value;
+  };
+
+  return (
+    <Card className="relative overflow-hidden">
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle>{title}</CardTitle>
+          {subtitle && <CardDescription>{subtitle}</CardDescription>}
+        </div>
+        {icon && <div className="text-primary/80">{icon}</div>}
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-3xl font-semibold tracking-tight text-foreground">{renderValue()}</p>
+        {trend && (
+          <div
+            className={cn(
+              'inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-medium',
+              trend.isPositive ? 'bg-emerald-500/10 text-emerald-400' : 'bg-red-500/10 text-red-400'
+            )}
+          >
+            <span>{trend.label}</span>
+            <span className="font-semibold">{formatPercentage(Math.abs(trend.value), 1)}</span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default MetricCard;

--- a/web/src/components/shared/NodeStatusPill.tsx
+++ b/web/src/components/shared/NodeStatusPill.tsx
@@ -1,0 +1,32 @@
+import { cn, formatTimeAgo } from '@/utils';
+import type { NodeSummary } from '@/types';
+
+interface NodeStatusPillProps {
+  node: Pick<NodeSummary, 'status' | 'lastSeen' | 'signalStrength' | 'battery'>;
+}
+
+const NodeStatusPill = ({ node }: NodeStatusPillProps) => {
+  const isOnline = node.status === 'online';
+
+  return (
+    <div
+      className={cn(
+        'inline-flex items-center gap-3 rounded-full border border-border/40 bg-slate-900/70 px-4 py-2 text-xs font-medium shadow-inner',
+        isOnline ? 'text-emerald-300' : 'text-rose-300'
+      )}
+    >
+      <span
+        className={cn('h-2.5 w-2.5 rounded-full', isOnline ? 'bg-emerald-400 shadow-emerald-400/60' : 'bg-rose-400 shadow-rose-400/60')}
+      />
+      <span>{isOnline ? 'Online' : 'Offline'}</span>
+      <span className="text-muted-foreground">·</span>
+      <span>Signal {node.signalStrength}%</span>
+      <span className="text-muted-foreground">·</span>
+      <span>Battery {node.battery}%</span>
+      <span className="text-muted-foreground">·</span>
+      <span>Last seen {formatTimeAgo(node.lastSeen)}</span>
+    </div>
+  );
+};
+
+export default NodeStatusPill;

--- a/web/src/components/ui/badge.tsx
+++ b/web/src/components/ui/badge.tsx
@@ -1,0 +1,33 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+import { cn } from '@/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'border-transparent bg-primary text-primary-foreground shadow',
+        secondary: 'border-transparent bg-secondary text-secondary-foreground',
+        destructive: 'border-transparent bg-destructive text-destructive-foreground shadow',
+        outline: 'text-foreground'
+      }
+    },
+    defaultVariants: {
+      variant: 'default'
+    }
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(
+  ({ className, variant, ...props }, ref) => (
+    <div ref={ref} className={cn(badgeVariants({ variant }), className)} {...props} />
+  )
+);
+Badge.displayName = 'Badge';
+
+export { Badge, badgeVariants };

--- a/web/src/components/ui/button.tsx
+++ b/web/src/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline:
+          'border border-input bg-transparent hover:bg-muted hover:text-muted-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-muted hover:text-muted-foreground',
+        link: 'text-primary underline-offset-4 hover:underline'
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10'
+      }
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default'
+    }
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+import { cn } from '@/utils';
+
+type CardProps = React.HTMLAttributes<HTMLDivElement>;
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      'rounded-xl border border-border/60 bg-card/60 text-card-foreground shadow-lg shadow-black/10 backdrop-blur-md',
+      className
+    )}
+    {...props}
+  />
+));
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col gap-2 border-b border-border/40 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, CardProps>((
+  { className, ...props },
+  ref
+) => <div ref={ref} className={cn('p-6', className)} {...props} />);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, CardProps>((
+  { className, ...props },
+  ref
+) => <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+import { cn } from '@/utils';
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { cn } from '@/utils';
+
+const Label = React.forwardRef<
+  HTMLLabelElement,
+  React.LabelHTMLAttributes<HTMLLabelElement>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn(
+      'text-sm font-medium leading-none text-muted-foreground peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+      className
+    )}
+    {...props}
+  />
+));
+Label.displayName = 'Label';
+
+export { Label };

--- a/web/src/context/AuthContext.tsx
+++ b/web/src/context/AuthContext.tsx
@@ -1,0 +1,169 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type PropsWithChildren
+} from 'react';
+import { apiClient } from '@/services/api';
+import { getDemoAuth } from '@/mock/demoData';
+import type { AuthResponse, User } from '@/types';
+
+interface AuthContextValue {
+  user: User | null;
+  accessToken: string | null;
+  loading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  register: (email: string, password: string, name?: string) => Promise<void>;
+  logout: () => void;
+  refreshSession: () => Promise<void>;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+const ACCESS_KEY = 'vineguard.access';
+const REFRESH_KEY = 'vineguard.refresh';
+const USER_KEY = 'vineguard.user';
+
+const persist = (user: User, tokens: AuthResponse['tokens']) => {
+  sessionStorage.setItem(ACCESS_KEY, tokens.accessToken);
+  sessionStorage.setItem(USER_KEY, JSON.stringify(user));
+  localStorage.setItem(REFRESH_KEY, tokens.refreshToken);
+};
+
+const clearPersisted = () => {
+  sessionStorage.removeItem(ACCESS_KEY);
+  sessionStorage.removeItem(USER_KEY);
+  localStorage.removeItem(REFRESH_KEY);
+};
+
+export const AuthProvider = ({ children }: PropsWithChildren) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [accessToken, setAccessToken] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const handleAuthSuccess = useCallback(
+    (response: AuthResponse) => {
+      setUser(response.user);
+      setAccessToken(response.tokens.accessToken);
+      setRefreshToken(response.tokens.refreshToken);
+      apiClient.setTokens(response.tokens.accessToken, response.tokens.refreshToken);
+      persist(response.user, response.tokens);
+    },
+    []
+  );
+
+  const logout = useCallback(() => {
+    clearPersisted();
+    setUser(null);
+    setAccessToken(null);
+    setRefreshToken(null);
+    apiClient.clearTokens();
+  }, []);
+
+  const bootstrap = useCallback(async () => {
+    const storedRefresh = localStorage.getItem(REFRESH_KEY);
+    const storedAccess = sessionStorage.getItem(ACCESS_KEY);
+    const storedUser = sessionStorage.getItem(USER_KEY);
+
+    if (storedRefresh) {
+      setRefreshToken(storedRefresh);
+      apiClient.setTokens(storedAccess ?? undefined, storedRefresh);
+    }
+
+    if (storedUser && storedAccess) {
+      const parsedUser = JSON.parse(storedUser) as User;
+      setUser(parsedUser);
+      setAccessToken(storedAccess);
+    }
+
+    if (storedRefresh) {
+      try {
+        const refreshed = await apiClient.refreshSession();
+        handleAuthSuccess(refreshed);
+      } catch (error) {
+        console.warn('Refresh failed, falling back to demo mode', error);
+        if (!storedUser) {
+          const demo = getDemoAuth();
+          handleAuthSuccess(demo);
+        } else {
+          logout();
+        }
+      }
+    }
+
+    setLoading(false);
+  }, [handleAuthSuccess, logout]);
+
+  useEffect(() => {
+    bootstrap().catch((error) => {
+      console.error('Bootstrap auth failed', error);
+      setLoading(false);
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      setLoading(true);
+      try {
+        const response = await apiClient.login(email, password);
+        handleAuthSuccess(response);
+      } catch (error) {
+        console.warn('Login failed, using demo auth', error);
+        const demo = getDemoAuth(email);
+        handleAuthSuccess(demo);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [handleAuthSuccess]
+  );
+
+  const register = useCallback(
+    async (email: string, password: string, name?: string) => {
+      setLoading(true);
+      try {
+        const response = await apiClient.register(email, password, name);
+        handleAuthSuccess(response);
+      } catch (error) {
+        console.warn('Register failed, using demo auth', error);
+        const demo = getDemoAuth(email, name ?? 'Demo Grower');
+        handleAuthSuccess(demo);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [handleAuthSuccess]
+  );
+
+
+  const refreshSession = useCallback(async () => {
+    if (!refreshToken) return;
+    try {
+      const refreshed = await apiClient.refreshSession();
+      handleAuthSuccess(refreshed);
+    } catch (error) {
+      console.error('Refresh session failed', error);
+      const demo = getDemoAuth();
+      handleAuthSuccess(demo);
+    }
+  }, [handleAuthSuccess, refreshToken]);
+
+  const value = useMemo(
+    () => ({ user, accessToken, loading, login, register, logout, refreshSession }),
+    [user, accessToken, loading, login, register, logout, refreshSession]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+};
+
+export const useAuthContext = () => {
+  const context = useContext(AuthContext);
+  if (!context) throw new Error('useAuthContext must be used within AuthProvider');
+  return context;
+};

--- a/web/src/hooks/useAuth.ts
+++ b/web/src/hooks/useAuth.ts
@@ -1,0 +1,3 @@
+import { useAuthContext } from '@/context/AuthContext';
+
+export const useAuth = () => useAuthContext();

--- a/web/src/hooks/useLiveTelemetry.ts
+++ b/web/src/hooks/useLiveTelemetry.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react';
+import { apiClient } from '@/services/api';
+import type { NodeTelemetryPoint } from '@/types';
+
+export const useLiveTelemetry = (
+  orgId: string | undefined,
+  onTelemetry: (payload: NodeTelemetryPoint) => void
+) => {
+  const callbackRef = useRef(onTelemetry);
+
+  useEffect(() => {
+    callbackRef.current = onTelemetry;
+  }, [onTelemetry]);
+
+  useEffect(() => {
+    if (!orgId) return;
+    const unsubscribe = apiClient.subscribeToLive(orgId, (payload) => {
+      callbackRef.current(payload);
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [orgId]);
+};

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,0 +1,52 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  --background: 222 47% 11%;
+  --foreground: 210 40% 98%;
+  --card: 222 47% 15%;
+  --card-foreground: 210 40% 98%;
+  --popover: 222 47% 15%;
+  --popover-foreground: 210 40% 98%;
+  --primary: 153 71% 59%;
+  --primary-foreground: 222 47% 11%;
+  --secondary: 222 47% 20%;
+  --secondary-foreground: 210 40% 96%;
+  --muted: 222 47% 25%;
+  --muted-foreground: 215 20.2% 65.1%;
+  --accent: 153 71% 59%;
+  --accent-foreground: 222 47% 11%;
+  --destructive: 0 62.8% 30.6%;
+  --destructive-foreground: 210 40% 98%;
+  --border: 222 47% 25%;
+  --input: 222 47% 25%;
+  --ring: 153 71% 59%;
+  --radius: 0.75rem;
+}
+
+body {
+  @apply bg-background text-foreground antialiased;
+}
+
+* {
+  @apply border-border;
+}
+
+a {
+  @apply text-primary hover:underline;
+}
+
+::-webkit-scrollbar {
+  width: 12px;
+}
+
+::-webkit-scrollbar-track {
+  background: hsl(var(--background));
+}
+
+::-webkit-scrollbar-thumb {
+  background-color: hsl(var(--secondary));
+  border-radius: 9999px;
+  border: 3px solid hsl(var(--background));
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+import { AuthProvider } from './context/AuthContext';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/web/src/mock/demoData.ts
+++ b/web/src/mock/demoData.ts
@@ -1,0 +1,206 @@
+import type {
+  AuthResponse,
+  Insight,
+  NodeDetail,
+  NodeTelemetryPoint,
+  OrgOverview,
+  Site
+} from '@/types';
+
+const baseTimestamp = Date.now();
+
+const makeTelemetrySeries = (seed: number, nodeId?: string): NodeTelemetryPoint[] => {
+  return Array.from({ length: 72 }, (_, index) => {
+    const time = baseTimestamp - (72 - index) * 5 * 60 * 1000;
+    const soilMoisture = 35 + Math.sin((index + seed) / 4) * 5 + Math.random() * 2;
+    const soilTemp = 18 + Math.sin((index + seed) / 8) * 2 + Math.random();
+    const airTemp = 22 + Math.sin((index + seed) / 6) * 3 + Math.random() * 2;
+    const humidity = 55 + Math.cos((index + seed) / 7) * 10 + Math.random() * 4;
+    const light = 600 + Math.sin((index + seed) / 3) * 300 + Math.random() * 50;
+    const battery = 80 - index * 0.05 + Math.random();
+
+    return {
+      timestamp: new Date(time).toISOString(),
+      soilMoisture: Math.max(10, Math.min(soilMoisture, 90)),
+      soilTemp: Math.max(5, Math.min(soilTemp, 40)),
+      airTemp: Math.max(5, Math.min(airTemp, 45)),
+      humidity: Math.max(30, Math.min(humidity, 99)),
+      light: Math.max(0, light),
+      battery: Math.max(20, Math.min(battery, 100)),
+      nodeId
+    };
+  });
+};
+
+const nodeSummaries = [
+  {
+    id: 'alpha',
+    name: 'Block A - North',
+    soilMoisture: 38,
+    battery: 76,
+    signalStrength: 88,
+    lastSeen: new Date(baseTimestamp - 60 * 1000).toISOString(),
+    status: 'online' as const
+  },
+  {
+    id: 'bravo',
+    name: 'Block A - South',
+    soilMoisture: 34,
+    battery: 69,
+    signalStrength: 81,
+    lastSeen: new Date(baseTimestamp - 6 * 60 * 1000).toISOString(),
+    status: 'online' as const
+  },
+  {
+    id: 'charlie',
+    name: 'Block B - Creek',
+    soilMoisture: 29,
+    battery: 42,
+    signalStrength: 62,
+    lastSeen: new Date(baseTimestamp - 18 * 60 * 1000).toISOString(),
+    status: 'offline' as const
+  }
+];
+
+export const demoSites: Site[] = [
+  {
+    id: 'demo-vineyard',
+    name: 'Napa Estate Vineyard',
+    description: '12 hectare drip irrigated block with volcanic soil and rolling hills.',
+    coordinates: { lat: 38.5025, lng: -122.2654 },
+    nodes: nodeSummaries
+  },
+  {
+    id: 'demo-valley',
+    name: 'Rutherford Valley',
+    description: 'Loamy soil near the river bank with premium cabernet blocks.',
+    coordinates: { lat: 38.4621, lng: -122.4214 },
+    nodes: [nodeSummaries[1]]
+  }
+];
+
+const nodeDetails: Record<string, NodeDetail> = {
+  alpha: {
+    ...nodeSummaries[0],
+    siteId: 'demo-vineyard',
+    firmwareVersion: '2.4.1',
+    publishIntervalSec: 900
+  },
+  bravo: {
+    ...nodeSummaries[1],
+    siteId: 'demo-vineyard',
+    firmwareVersion: '2.4.1',
+    publishIntervalSec: 900
+  },
+  charlie: {
+    ...nodeSummaries[2],
+    siteId: 'demo-vineyard',
+    firmwareVersion: '2.3.5',
+    publishIntervalSec: 1200
+  }
+};
+
+const telemetryMap: Record<string, NodeTelemetryPoint[]> = {
+  alpha: makeTelemetrySeries(3, 'alpha'),
+  bravo: makeTelemetrySeries(9, 'bravo'),
+  charlie: makeTelemetrySeries(14, 'charlie')
+};
+
+export const demoInsights: Insight[] = [
+  {
+    id: 'insight-1',
+    siteId: 'demo-vineyard',
+    nodeId: 'alpha',
+    type: 'irrigation',
+    severity: 'medium',
+    message: 'Soil moisture trending low, consider irrigating in the next 8 hours.',
+    timestamp: new Date(baseTimestamp - 45 * 60 * 1000).toISOString()
+  },
+  {
+    id: 'insight-2',
+    siteId: 'demo-vineyard',
+    nodeId: 'charlie',
+    type: 'battery',
+    severity: 'high',
+    message: 'Battery health at 42%, schedule maintenance soon.',
+    timestamp: new Date(baseTimestamp - 2 * 60 * 60 * 1000).toISOString()
+  },
+  {
+    id: 'insight-3',
+    siteId: 'demo-valley',
+    nodeId: 'bravo',
+    type: 'disease',
+    severity: 'low',
+    message: 'Powdery mildew pressure increasing due to humidity swing.',
+    timestamp: new Date(baseTimestamp - 90 * 60 * 1000).toISOString()
+  }
+];
+
+export const demoOverview: OrgOverview = {
+  totalNodes: nodeSummaries.length,
+  onlineNodes: nodeSummaries.filter((node) => node.status === 'online').length,
+  avgSoilMoisture:
+    nodeSummaries.reduce((sum, node) => sum + node.soilMoisture, 0) / nodeSummaries.length,
+  batteryWarnings: nodeSummaries.filter((node) => node.battery < 50).length
+};
+
+export const getDemoNodeDetail = (nodeId: string): NodeDetail => {
+  return nodeDetails[nodeId] ?? {
+    id: nodeId,
+    name: `Node ${nodeId}`,
+    soilMoisture: 0,
+    battery: 0,
+    signalStrength: 0,
+    lastSeen: new Date().toISOString(),
+    status: 'offline',
+    siteId: 'demo-vineyard',
+    firmwareVersion: 'unknown',
+    publishIntervalSec: 900
+  };
+};
+
+export const getDemoTelemetry = (nodeId: string): NodeTelemetryPoint[] => {
+  return telemetryMap[nodeId] ?? makeTelemetrySeries(Math.floor(Math.random() * 10), nodeId);
+};
+
+export const getDemoInsights = () => demoInsights;
+
+export const getDemoAuth = (email = 'demo@vineguard.io', name = 'Demo Grower'): AuthResponse => ({
+  user: {
+    id: 'demo-user',
+    email,
+    name,
+    orgId: 'demo-org'
+  },
+  tokens: {
+    accessToken: 'demo-access-token',
+    refreshToken: 'demo-refresh-token'
+  }
+});
+
+export const createMockLiveSample = (nodeId: string): NodeTelemetryPoint => {
+  const base = telemetryMap[nodeId]?.[telemetryMap[nodeId].length - 1] ?? makeTelemetrySeries(2, nodeId).slice(-1)[0];
+  const timestamp = new Date().toISOString();
+  const jitter = (value: number, delta: number) => value + (Math.random() - 0.5) * delta;
+  const sample = base ?? {
+    timestamp,
+    soilMoisture: 35,
+    soilTemp: 18,
+    airTemp: 22,
+    humidity: 55,
+    light: 600,
+    battery: 80,
+    nodeId
+  };
+
+  return {
+    timestamp,
+    soilMoisture: Math.max(5, Math.min(jitter(sample.soilMoisture, 2), 90)),
+    soilTemp: Math.max(0, Math.min(jitter(sample.soilTemp, 1.5), 40)),
+    airTemp: Math.max(0, Math.min(jitter(sample.airTemp, 2.5), 45)),
+    humidity: Math.max(20, Math.min(jitter(sample.humidity, 5), 99)),
+    light: Math.max(0, jitter(sample.light, 120)),
+    battery: Math.max(10, Math.min(sample.battery - Math.random() * 0.1, 100)),
+    nodeId
+  };
+};

--- a/web/src/pages/Auth/LoginPage.tsx
+++ b/web/src/pages/Auth/LoginPage.tsx
@@ -1,0 +1,75 @@
+import { FormEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const LoginPage = () => {
+  const { login, loading } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('demo@vineguard.io');
+  const [password, setPassword] = useState('demo1234');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      await login(email, password);
+      navigate('/', { replace: true });
+    } catch (err) {
+      setError('Unable to authenticate. Please try again.');
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-4">
+      <div className="w-full max-w-md rounded-3xl border border-border/40 bg-slate-900/70 p-10 shadow-2xl shadow-primary/20 backdrop-blur-xl">
+        <div className="mb-8 text-center">
+          <p className="text-sm uppercase tracking-[0.3em] text-primary/80">Welcome back</p>
+          <h1 className="mt-2 text-3xl font-semibold text-slate-50">Log in to VineGuard</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            Use the seeded demo credentials or your organization account.
+          </p>
+        </div>
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="email">Email address</Label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-sm text-rose-400">{error}</p>}
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Signing in…' : 'Sign in'}
+          </Button>
+        </form>
+        <p className="mt-8 text-center text-sm text-muted-foreground">
+          Need access?{' '}
+          <Link to="/register" className="text-primary hover:text-primary/80">
+            Create an account
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/web/src/pages/Auth/RegisterPage.tsx
+++ b/web/src/pages/Auth/RegisterPage.tsx
@@ -1,0 +1,80 @@
+import { FormEvent, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import { useAuth } from '@/hooks/useAuth';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+const RegisterPage = () => {
+  const { register, loading } = useAuth();
+  const navigate = useNavigate();
+  const [name, setName] = useState('Demo Grower');
+  const [email, setEmail] = useState('demo@vineguard.io');
+  const [password, setPassword] = useState('demo1234');
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      await register(email, password, name);
+      navigate('/', { replace: true });
+    } catch (err) {
+      setError('Unable to create account. Please try again later.');
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950 px-4">
+      <div className="w-full max-w-md rounded-3xl border border-border/40 bg-slate-900/70 p-10 shadow-2xl shadow-primary/20 backdrop-blur-xl">
+        <div className="mb-8 text-center">
+          <p className="text-sm uppercase tracking-[0.3em] text-primary/80">Get started</p>
+          <h1 className="mt-2 text-3xl font-semibold text-slate-50">Create your VineGuard account</h1>
+          <p className="mt-2 text-sm text-muted-foreground">
+            The demo organization comes preloaded with vineyard telemetry and alerts.
+          </p>
+        </div>
+        <form className="space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-2">
+            <Label htmlFor="name">Full name</Label>
+            <Input id="name" value={name} onChange={(event) => setName(event.target.value)} required />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="email">Work email</Label>
+            <Input
+              id="email"
+              type="email"
+              autoComplete="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+            />
+          </div>
+          {error && <p className="text-sm text-rose-400">{error}</p>}
+          <Button type="submit" className="w-full" disabled={loading}>
+            {loading ? 'Creating account…' : 'Create account'}
+          </Button>
+        </form>
+        <p className="mt-8 text-center text-sm text-muted-foreground">
+          Already have access?{' '}
+          <Link to="/login" className="text-primary hover:text-primary/80">
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterPage;

--- a/web/src/pages/Dashboard/OverviewPage.tsx
+++ b/web/src/pages/Dashboard/OverviewPage.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useMemo, useState } from 'react';
+import MetricCard from '@/components/shared/MetricCard';
+import TimeSeriesChart from '@/components/charts/TimeSeriesChart';
+import NodeStatusPill from '@/components/shared/NodeStatusPill';
+import { apiClient } from '@/services/api';
+import { useAuth } from '@/hooks/useAuth';
+import type { NodeTelemetryPoint, OrgOverview, Site } from '@/types';
+import { formatPercentage } from '@/utils';
+import { Droplets, Leaf, RadioTower, ShieldAlert } from 'lucide-react';
+
+const OverviewPage = () => {
+  const { user } = useAuth();
+  const [overview, setOverview] = useState<OrgOverview | null>(null);
+  const [sites, setSites] = useState<Site[]>([]);
+  const [chartData, setChartData] = useState<NodeTelemetryPoint[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!user?.orgId) return;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        const [overviewData, sitesData] = await Promise.all([
+          apiClient.fetchOrgOverview(user.orgId),
+          apiClient.fetchSites(user.orgId)
+        ]);
+        if (cancelled) return;
+        setOverview(overviewData);
+        setSites(sitesData);
+
+        const primarySite = sitesData[0];
+        if (primarySite && primarySite.nodes.length > 0) {
+          const telemetrySeries = await Promise.all(
+            primarySite.nodes.map((node) => apiClient.fetchNodeTelemetry(node.id, '6h'))
+          );
+          if (cancelled) return;
+          if (!telemetrySeries.length || telemetrySeries[0].length === 0) {
+            setChartData([]);
+            return;
+          }
+          const aggregated = telemetrySeries[0].map((point, index) => {
+            const timestamp = point.timestamp;
+            const soilMoisture = telemetrySeries.reduce(
+              (sum, series) => sum + (series[index]?.soilMoisture ?? series[series.length - 1]?.soilMoisture ?? 0),
+              0
+            );
+            const airTemp = telemetrySeries.reduce(
+              (sum, series) => sum + (series[index]?.airTemp ?? series[series.length - 1]?.airTemp ?? 0),
+              0
+            );
+            const humidity = telemetrySeries.reduce(
+              (sum, series) => sum + (series[index]?.humidity ?? series[series.length - 1]?.humidity ?? 0),
+              0
+            );
+            const battery = telemetrySeries.reduce(
+              (sum, series) => sum + (series[index]?.battery ?? series[series.length - 1]?.battery ?? 0),
+              0
+            );
+            const count = telemetrySeries.length || 1;
+
+            return {
+              ...point,
+              timestamp,
+              soilMoisture: soilMoisture / count,
+              airTemp: airTemp / count,
+              humidity: humidity / count,
+              battery: battery / count
+            };
+          });
+          setChartData(aggregated);
+        }
+      } catch (error) {
+        console.error('Failed to load overview data', error);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.orgId]);
+
+  const metrics = useMemo(() => {
+    if (!overview) return [];
+    return [
+      {
+        title: 'Total nodes',
+        value: overview.totalNodes,
+        subtitle: 'Across all vineyard blocks',
+        icon: <RadioTower className="h-5 w-5" />,
+        trend: { label: 'Active deployment', value: overview.onlineNodes / Math.max(overview.totalNodes, 1), isPositive: true }
+      },
+      {
+        title: 'Online nodes',
+        value: overview.onlineNodes,
+        subtitle: 'Reporting in the last hour',
+        icon: <Leaf className="h-5 w-5" />,
+        trend: {
+          label: 'Availability',
+          value: overview.onlineNodes / Math.max(overview.totalNodes, 1),
+          isPositive: overview.onlineNodes / Math.max(overview.totalNodes, 1) > 0.7
+        }
+      },
+      {
+        title: 'Avg soil moisture',
+        value: overview.avgSoilMoisture,
+        subtitle: 'Weighted average across blocks',
+        icon: <Droplets className="h-5 w-5" />,
+        format: (value: number | string) => formatPercentage(Number(value), 1)
+      },
+      {
+        title: 'Battery warnings',
+        value: overview.batteryWarnings,
+        subtitle: 'Nodes below 50% capacity',
+        icon: <ShieldAlert className="h-5 w-5" />,
+        trend: {
+          label: 'Maintenance load',
+          value: overview.batteryWarnings / Math.max(overview.totalNodes, 1),
+          isPositive: overview.batteryWarnings === 0
+        }
+      }
+    ];
+  }, [overview]);
+
+  return (
+    <div className="space-y-8">
+      <div className="grid gap-6 sm:grid-cols-2 xl:grid-cols-4">
+        {metrics.map((metric) => (
+          <MetricCard key={metric.title} {...metric} />
+        ))}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <TimeSeriesChart
+            title="Vineyard moisture and climate"
+            data={chartData}
+            series={[
+              { dataKey: 'soilMoisture', name: 'Soil moisture (%)', color: '#34d399' },
+              { dataKey: 'airTemp', name: 'Air temp (°C)', color: '#60a5fa' },
+              { dataKey: 'humidity', name: 'Humidity (%)', color: '#a855f7' }
+            ]}
+          />
+        </div>
+        <div className="space-y-4 rounded-2xl border border-border/40 bg-slate-900/50 p-6">
+          <div>
+            <h2 className="text-lg font-semibold text-foreground">Live node health</h2>
+            <p className="text-sm text-muted-foreground">
+              Latest check-ins across your deployment with connectivity and battery.
+            </p>
+          </div>
+          <div className="space-y-4">
+            {(sites[0]?.nodes ?? []).map((node) => (
+              <div key={node.id} className="space-y-2">
+                <p className="text-sm font-semibold text-foreground">{node.name}</p>
+                <NodeStatusPill node={node} />
+              </div>
+            ))}
+            {!loading && sites.length === 0 && (
+              <p className="text-sm text-muted-foreground">No nodes assigned to this organization yet.</p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default OverviewPage;

--- a/web/src/pages/Insights/InsightsPage.tsx
+++ b/web/src/pages/Insights/InsightsPage.tsx
@@ -1,0 +1,146 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import InsightBadge from '@/components/shared/InsightBadge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { useAuth } from '@/hooks/useAuth';
+import { apiClient } from '@/services/api';
+import type { Insight, InsightType } from '@/types';
+import { formatDateTime } from '@/utils';
+import { Button } from '@/components/ui/button';
+
+const timeRanges = [
+  { label: '24 hours', value: '24h', delta: 24 * 60 * 60 * 1000 },
+  { label: '7 days', value: '7d', delta: 7 * 24 * 60 * 60 * 1000 },
+  { label: '30 days', value: '30d', delta: 30 * 24 * 60 * 60 * 1000 }
+];
+
+const types: Array<{ label: string; value: InsightType | 'all' }> = [
+  { label: 'All types', value: 'all' },
+  { label: 'Irrigation', value: 'irrigation' },
+  { label: 'Disease', value: 'disease' },
+  { label: 'Battery', value: 'battery' }
+];
+
+const InsightsPage = () => {
+  const { user } = useAuth();
+  const [insights, setInsights] = useState<Insight[]>([]);
+  const [search, setSearch] = useState('');
+  const [selectedType, setSelectedType] = useState<InsightType | 'all'>('all');
+  const [range, setRange] = useState(timeRanges[1]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!user?.orgId) return;
+
+    const load = async () => {
+      setLoading(true);
+      try {
+        const to = new Date();
+        const from = new Date(to.getTime() - range.delta);
+        const data = await apiClient.fetchInsights(user.orgId, {
+          type: selectedType === 'all' ? undefined : selectedType,
+          from: from.toISOString(),
+          to: to.toISOString()
+        });
+        if (!cancelled) setInsights(data);
+      } catch (error) {
+        console.error('Failed to load insights', error);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [user?.orgId, selectedType, range]);
+
+  const filtered = useMemo(() => {
+    if (!search) return insights;
+    const term = search.toLowerCase();
+    return insights.filter((insight) => insight.message.toLowerCase().includes(term));
+  }, [insights, search]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">Irrigation & disease insights</h1>
+          <p className="text-sm text-muted-foreground">
+            Review actionable telemetry-driven recommendations and plan maintenance.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          {types.map((type) => (
+            <Button
+              key={type.value}
+              variant={selectedType === type.value ? 'default' : 'ghost'}
+              onClick={() => setSelectedType(type.value)}
+            >
+              {type.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-[1fr_auto]">
+        <Input
+          placeholder="Search insight text…"
+          value={search}
+          onChange={(event) => setSearch(event.target.value)}
+          className="border-border/60 bg-slate-900/50"
+        />
+        <select
+          className="h-10 rounded-md border border-border/60 bg-slate-900/60 px-3 text-sm text-foreground"
+          value={range.value}
+          onChange={(event) => {
+            const next = timeRanges.find((option) => option.value === event.target.value);
+            if (next) setRange(next);
+          }}
+        >
+          {timeRanges.map((option) => (
+            <option key={option.value} value={option.value}>
+              Last {option.label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <Card className="border-border/40 bg-slate-900/60">
+        <CardHeader>
+          <CardTitle className="text-lg font-semibold text-foreground">{filtered.length} insights</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {loading && <p className="text-sm text-muted-foreground">Loading insights…</p>}
+          {!loading && filtered.length === 0 && (
+            <p className="text-sm text-muted-foreground">No insights match the selected filters.</p>
+          )}
+          {filtered.map((insight) => (
+            <div key={insight.id} className="rounded-xl border border-border/40 bg-slate-950/60 p-5 shadow-inner shadow-black/20">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-semibold text-foreground">{insight.message}</p>
+                  <p className="text-xs text-muted-foreground">{formatDateTime(insight.timestamp)}</p>
+                </div>
+                <InsightBadge type={insight.type} severity={insight.severity} />
+              </div>
+              <div className="mt-3 flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                <span>Node {insight.nodeId}</span>
+                <span>Site {insight.siteId}</span>
+                <Link to={`/nodes/${insight.nodeId}`} className="text-primary hover:text-primary/80">
+                  View node
+                </Link>
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default InsightsPage;

--- a/web/src/pages/Nodes/NodeDetailPage.tsx
+++ b/web/src/pages/Nodes/NodeDetailPage.tsx
@@ -1,0 +1,242 @@
+import { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { apiClient } from '@/services/api';
+import { useAuth } from '@/hooks/useAuth';
+import { useLiveTelemetry } from '@/hooks/useLiveTelemetry';
+import type { Insight, NodeDetail, NodeTelemetryPoint } from '@/types';
+import TimeSeriesChart from '@/components/charts/TimeSeriesChart';
+import NodeStatusPill from '@/components/shared/NodeStatusPill';
+import InsightBadge from '@/components/shared/InsightBadge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { formatDateTime } from '@/utils';
+
+const ranges = [
+  { label: '6h', value: '6h' },
+  { label: '24h', value: '24h' },
+  { label: '7d', value: '7d' }
+];
+
+const NodeDetailPage = () => {
+  const { nodeId } = useParams();
+  const { user } = useAuth();
+  const [node, setNode] = useState<NodeDetail | null>(null);
+  const [telemetry, setTelemetry] = useState<NodeTelemetryPoint[]>([]);
+  const [insights, setInsights] = useState<Insight[]>([]);
+  const [range, setRange] = useState('24h');
+  const [publishInterval, setPublishInterval] = useState(900);
+  const [otaUrl, setOtaUrl] = useState('');
+  const [commandStatus, setCommandStatus] = useState<'idle' | 'sending' | 'success' | 'error'>('idle');
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!nodeId) return;
+
+    const load = async () => {
+      try {
+        const [nodeData, telemetryData, insightData] = await Promise.all([
+          apiClient.fetchNode(nodeId),
+          apiClient.fetchNodeTelemetry(nodeId, range),
+          user?.orgId ? apiClient.fetchInsights(user.orgId, { nodeId }) : Promise.resolve([])
+        ]);
+        if (cancelled) return;
+        setNode(nodeData);
+        setPublishInterval(nodeData.publishIntervalSec);
+        setTelemetry(telemetryData);
+        setInsights(insightData);
+      } catch (error) {
+        console.error('Failed to load node data', error);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [nodeId, range, user?.orgId]);
+
+  const handleLive = useCallback(
+    (payload: NodeTelemetryPoint) => {
+      if (!nodeId) return;
+      if (payload.nodeId && payload.nodeId !== nodeId) return;
+      setTelemetry((prev) => {
+        const next = [...prev.slice(-200), { ...payload, nodeId }];
+        return next;
+      });
+      setNode((prev) =>
+        prev
+          ? {
+              ...prev,
+              soilMoisture: payload.soilMoisture,
+              battery: payload.battery,
+              lastSeen: payload.timestamp,
+              status: 'online'
+            }
+          : prev
+      );
+    },
+    [nodeId]
+  );
+
+  useLiveTelemetry(user?.orgId, handleLive);
+
+  const handleCommand = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!nodeId) return;
+    setCommandStatus('sending');
+    try {
+      await apiClient.sendCommand({ nodeId, publishIntervalSec: publishInterval, otaUrl: otaUrl || undefined });
+      setCommandStatus('success');
+      setTimeout(() => setCommandStatus('idle'), 2500);
+    } catch (error) {
+      console.error('Failed to send command', error);
+      setCommandStatus('error');
+    }
+  };
+
+  const latestTelemetry = useMemo(() => telemetry[telemetry.length - 1], [telemetry]);
+
+  if (!node) {
+    return (
+      <div className="rounded-2xl border border-border/40 bg-slate-900/40 p-8 text-sm text-muted-foreground">
+        Loading node diagnostics…
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-foreground">{node.name}</h1>
+          <p className="text-sm text-muted-foreground">
+            Firmware {node.firmwareVersion} · Reporting every {node.publishIntervalSec / 60} minutes
+          </p>
+        </div>
+        <NodeStatusPill node={node} />
+      </div>
+
+      <div className="flex flex-wrap gap-3">
+        {ranges.map((option) => (
+          <Button
+            key={option.value}
+            variant={option.value === range ? 'default' : 'ghost'}
+            onClick={() => setRange(option.value)}
+          >
+            Last {option.label}
+          </Button>
+        ))}
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <TimeSeriesChart
+          title="Soil moisture & soil temperature"
+          data={telemetry}
+          series={[
+            { dataKey: 'soilMoisture', name: 'Soil moisture (%)', color: '#34d399' },
+            { dataKey: 'soilTemp', name: 'Soil temp (°C)', color: '#f97316' }
+          ]}
+        />
+        <TimeSeriesChart
+          title="Air temperature & humidity"
+          data={telemetry}
+          series={[
+            { dataKey: 'airTemp', name: 'Air temp (°C)', color: '#60a5fa' },
+            { dataKey: 'humidity', name: 'Humidity (%)', color: '#a855f7' }
+          ]}
+        />
+        <TimeSeriesChart
+          title="Light intensity"
+          data={telemetry}
+          variant="line"
+          series={[{ dataKey: 'light', name: 'Light (lux)', color: '#facc15' }]}
+        />
+        <TimeSeriesChart
+          title="Battery voltage"
+          data={telemetry}
+          variant="line"
+          series={[{ dataKey: 'battery', name: 'Battery (%)', color: '#f472b6' }]}
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-[1.5fr_1fr]">
+        <Card className="border-border/40 bg-slate-900/60">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-foreground">Recent insights</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {insights.length === 0 && (
+              <p className="text-sm text-muted-foreground">No alerts for this node in the selected timeframe.</p>
+            )}
+            {insights.map((insight) => (
+              <div key={insight.id} className="rounded-xl border border-border/40 bg-slate-950/60 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div>
+                    <p className="text-sm font-semibold text-foreground">{insight.message}</p>
+                    <p className="text-xs text-muted-foreground">{formatDateTime(insight.timestamp)}</p>
+                  </div>
+                  <InsightBadge type={insight.type} severity={insight.severity} />
+                </div>
+              </div>
+            ))}
+          </CardContent>
+        </Card>
+
+        <Card className="border-border/40 bg-slate-900/60">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-foreground">Command & control</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form className="space-y-4" onSubmit={handleCommand}>
+              <div className="space-y-2">
+                <Label htmlFor="publishInterval">Publish interval (seconds)</Label>
+                <Input
+                  id="publishInterval"
+                  type="number"
+                  min={60}
+                  value={publishInterval}
+                  onChange={(event) => setPublishInterval(Number(event.target.value))}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="otaUrl">OTA firmware URL</Label>
+                <Input
+                  id="otaUrl"
+                  type="url"
+                  placeholder="https://updates.vineguard.io/firmware.bin"
+                  value={otaUrl}
+                  onChange={(event) => setOtaUrl(event.target.value)}
+                />
+              </div>
+              <Button type="submit" className="w-full" disabled={commandStatus === 'sending'}>
+                {commandStatus === 'sending' ? 'Dispatching…' : 'Send command'}
+              </Button>
+              {commandStatus === 'success' && (
+                <p className="text-sm text-emerald-400">Command queued successfully.</p>
+              )}
+              {commandStatus === 'error' && (
+                <p className="text-sm text-rose-400">Failed to queue command. Try again.</p>
+              )}
+            </form>
+            {latestTelemetry && (
+              <div className="mt-6 rounded-xl border border-border/40 bg-slate-950/60 p-4 text-sm text-muted-foreground">
+                <p className="font-semibold text-foreground">Latest reading</p>
+                <ul className="mt-2 space-y-1">
+                  <li>Soil moisture {latestTelemetry.soilMoisture.toFixed(1)}%</li>
+                  <li>Air temperature {latestTelemetry.airTemp.toFixed(1)}°C</li>
+                  <li>Humidity {latestTelemetry.humidity.toFixed(1)}%</li>
+                  <li>Battery {latestTelemetry.battery.toFixed(1)}%</li>
+                </ul>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default NodeDetailPage;

--- a/web/src/pages/Sites/SiteDetailPage.tsx
+++ b/web/src/pages/Sites/SiteDetailPage.tsx
@@ -1,0 +1,115 @@
+import { useEffect, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+import { apiClient } from '@/services/api';
+import { useAuth } from '@/hooks/useAuth';
+import type { Site } from '@/types';
+import NodeStatusPill from '@/components/shared/NodeStatusPill';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { MapPin } from 'lucide-react';
+
+const SiteDetailPage = () => {
+  const { siteId } = useParams();
+  const { user } = useAuth();
+  const [site, setSite] = useState<Site | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (!siteId) return;
+
+    const load = async () => {
+      try {
+        const data = await apiClient.fetchSite(siteId);
+        if (!cancelled) setSite(data);
+      } catch (error) {
+        console.error('Failed to load site detail', error);
+      }
+    };
+
+    load();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [siteId, user?.orgId]);
+
+  if (!site) {
+    return (
+      <div className="rounded-2xl border border-border/40 bg-slate-900/40 p-8 text-sm text-muted-foreground">
+        Loading site details…
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1.6fr_1fr]">
+      <Card className="overflow-hidden border-border/40 bg-slate-900/60">
+        <CardHeader className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-2xl font-semibold text-foreground">{site.name}</CardTitle>
+            <div className="inline-flex items-center gap-2 rounded-full border border-primary/40 bg-primary/5 px-3 py-1 text-xs text-primary">
+              <MapPin className="h-3.5 w-3.5" /> {site.coordinates.lat.toFixed(3)}, {site.coordinates.lng.toFixed(3)}
+            </div>
+          </div>
+          <p className="max-w-3xl text-sm text-muted-foreground">{site.description}</p>
+        </CardHeader>
+        <CardContent>
+          <div className="relative h-80 w-full overflow-hidden rounded-2xl border border-border/40 bg-gradient-to-br from-slate-800 via-slate-900 to-slate-950">
+            <div className="absolute inset-0 opacity-40" style={{
+              backgroundImage:
+                'radial-gradient(circle at 20% 20%, rgba(79, 70, 229, 0.3), transparent 55%), radial-gradient(circle at 80% 30%, rgba(16, 185, 129, 0.35), transparent 50%), radial-gradient(circle at 60% 75%, rgba(59, 130, 246, 0.3), transparent 45%)'
+            }} />
+            <div className="absolute inset-0 flex flex-col justify-between p-6 text-xs text-slate-300">
+              <div className="flex items-center justify-between">
+                <span>Vineyard heatmap</span>
+                <span>Signal overlay</span>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {site.nodes.map((node) => (
+                  <div key={node.id} className="rounded-xl border border-border/40 bg-slate-900/60 p-4">
+                    <p className="text-sm font-semibold text-foreground">{node.name}</p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      Signal {node.signalStrength}% · Soil moisture {node.soilMoisture}%
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">Battery {node.battery}%</p>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="space-y-6">
+        <Card className="border-border/40 bg-slate-900/60">
+          <CardHeader>
+            <CardTitle className="text-lg font-semibold text-foreground">Node roster</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {site.nodes.map((node) => (
+              <div key={node.id} className="rounded-xl border border-border/40 bg-slate-900/50 p-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p className="font-semibold text-foreground">{node.name}</p>
+                    <p className="text-xs text-muted-foreground">Last seen {new Date(node.lastSeen).toLocaleTimeString()}</p>
+                  </div>
+                  <Button asChild variant="ghost" className="text-xs text-primary">
+                    <Link to={`/nodes/${node.id}`}>View node</Link>
+                  </Button>
+                </div>
+                <div className="mt-3">
+                  <NodeStatusPill node={node} />
+                </div>
+              </div>
+            ))}
+            {site.nodes.length === 0 && (
+              <p className="text-sm text-muted-foreground">No telemetry nodes assigned to this site.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default SiteDetailPage;

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -1,0 +1,239 @@
+import type {
+  AuthResponse,
+  CommandPayload,
+  Insight,
+  NodeDetail,
+  NodeTelemetryPoint,
+  OrgOverview,
+  Site
+} from '@/types';
+import {
+  createMockLiveSample,
+  demoInsights,
+  demoOverview,
+  demoSites,
+  getDemoAuth,
+  getDemoNodeDetail,
+  getDemoTelemetry
+} from '@/mock/demoData';
+
+interface RequestOptions<T> {
+  fallback?: () => T | Promise<T>;
+  skipAuth?: boolean;
+}
+
+const withTrailingSlash = (value: string) => (value.endsWith('/') ? value.slice(0, -1) : value);
+
+export class ApiClient {
+  private accessToken: string | null = null;
+  private refreshToken: string | null = null;
+  private readonly baseUrl: string;
+
+  constructor(baseUrl: string) {
+    this.baseUrl = withTrailingSlash(baseUrl || '');
+  }
+
+  setTokens(access?: string, refresh?: string) {
+    if (access) this.accessToken = access;
+    if (refresh) this.refreshToken = refresh;
+  }
+
+  clearTokens() {
+    this.accessToken = null;
+    this.refreshToken = null;
+  }
+
+  async login(email: string, password: string): Promise<AuthResponse> {
+    return this.request<AuthResponse>(
+      '/auth/login',
+      {
+        method: 'POST',
+        body: JSON.stringify({ email, password })
+      },
+      {
+        skipAuth: true,
+        fallback: () => getDemoAuth(email)
+      }
+    );
+  }
+
+  async register(email: string, password: string, name?: string): Promise<AuthResponse> {
+    return this.request<AuthResponse>(
+      '/auth/register',
+      {
+        method: 'POST',
+        body: JSON.stringify({ email, password, name })
+      },
+      {
+        skipAuth: true,
+        fallback: () => getDemoAuth(email, name ?? 'Demo Grower')
+      }
+    );
+  }
+
+  async refreshSession(): Promise<AuthResponse> {
+    if (!this.refreshToken) {
+      return getDemoAuth();
+    }
+
+    return this.request<AuthResponse>(
+      '/auth/refresh',
+      {
+        method: 'POST',
+        body: JSON.stringify({ refreshToken: this.refreshToken })
+      },
+      {
+        skipAuth: true,
+        fallback: () => getDemoAuth()
+      }
+    );
+  }
+
+  async fetchOrgOverview(orgId: string): Promise<OrgOverview> {
+    return this.request<OrgOverview>(`/orgs/${orgId}/overview`, undefined, {
+      fallback: () => ({ ...demoOverview })
+    });
+  }
+
+  async fetchSites(orgId: string): Promise<Site[]> {
+    return this.request<Site[]>(`/orgs/${orgId}/sites`, undefined, {
+      fallback: () => demoSites.map((site) => ({ ...site, nodes: site.nodes.map((node) => ({ ...node })) }))
+    });
+  }
+
+  async fetchSite(siteId: string): Promise<Site> {
+    return this.request<Site>(`/sites/${siteId}`, undefined, {
+      fallback: () =>
+        demoSites
+          .map((site) => ({ ...site, nodes: site.nodes.map((node) => ({ ...node })) }))
+          .find((site) => site.id === siteId) ?? demoSites[0]
+    });
+  }
+
+  async fetchNode(nodeId: string): Promise<NodeDetail> {
+    return this.request<NodeDetail>(`/nodes/${nodeId}`, undefined, {
+      fallback: () => ({ ...getDemoNodeDetail(nodeId) })
+    });
+  }
+
+  async fetchNodeTelemetry(nodeId: string, range: string): Promise<NodeTelemetryPoint[]> {
+    return this.request<NodeTelemetryPoint[]>(`/nodes/${nodeId}/telemetry?range=${range}`, undefined, {
+      fallback: () => getDemoTelemetry(nodeId).map((point) => ({ ...point }))
+    });
+  }
+
+  async fetchInsights(orgId: string, params: Record<string, string | undefined>): Promise<Insight[]> {
+    const query = new URLSearchParams();
+    Object.entries(params).forEach(([key, value]) => {
+      if (value) query.set(key, value);
+    });
+    const suffix = query.toString() ? `?${query.toString()}` : '';
+    return this.request<Insight[]>(`/orgs/${orgId}/insights${suffix}`, undefined, {
+      fallback: () => demoInsights.map((insight) => ({ ...insight }))
+    });
+  }
+
+  async sendCommand(payload: CommandPayload): Promise<void> {
+    await this.request(
+      '/commands',
+      {
+        method: 'POST',
+        body: JSON.stringify(payload)
+      },
+      {
+        fallback: () => undefined
+      }
+    );
+  }
+
+  subscribeToLive(orgId: string, onMessage: (payload: NodeTelemetryPoint) => void) {
+    const liveUrl = `${this.baseUrl}/live/${orgId}`;
+    let eventSource: EventSource | null = null;
+    let isClosed = false;
+
+    if (typeof window !== 'undefined' && 'EventSource' in window) {
+      eventSource = new EventSource(liveUrl, { withCredentials: true });
+      eventSource.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data) as NodeTelemetryPoint;
+          onMessage(data);
+        } catch (error) {
+          console.warn('Failed to parse live event', error);
+        }
+      };
+      eventSource.onerror = (error) => {
+        console.error('Live stream error, closing EventSource', error);
+        eventSource?.close();
+        if (!isClosed) {
+          startPollingFallback();
+        }
+      };
+    } else {
+      startPollingFallback();
+    }
+
+    const intervalHandles: Array<ReturnType<typeof setInterval>> = [];
+
+    function startPollingFallback() {
+      const nodeIds = demoSites.flatMap((site) => site.nodes.map((node) => node.id));
+      const handle = setInterval(() => {
+        const target = nodeIds[Math.floor(Math.random() * nodeIds.length)] ?? 'alpha';
+        onMessage(createMockLiveSample(target));
+      }, 5000);
+      intervalHandles.push(handle);
+    }
+
+    return () => {
+      isClosed = true;
+      eventSource?.close();
+      intervalHandles.forEach((handle) => clearInterval(handle));
+    };
+  }
+
+  private async request<T>(path: string, init?: RequestInit, options: RequestOptions<T> = {}): Promise<T> {
+    const { fallback, skipAuth } = options;
+    const headers = new Headers(init?.headers);
+    if (init?.body && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+    if (!skipAuth && this.accessToken) {
+      headers.set('Authorization', `Bearer ${this.accessToken}`);
+    }
+
+    const requestInit: RequestInit = {
+      credentials: 'include',
+      ...init,
+      headers
+    };
+
+    if (!this.baseUrl) {
+      if (fallback) {
+        return await fallback();
+      }
+      throw new Error('API base URL is not configured.');
+    }
+
+    try {
+      const response = await fetch(`${this.baseUrl}${path}`, requestInit);
+      if (response.status === 401 && !skipAuth && this.refreshToken) {
+        const refreshed = await this.refreshSession();
+        this.setTokens(refreshed.tokens.accessToken, refreshed.tokens.refreshToken);
+        return this.request<T>(path, init, options);
+      }
+      if (!response.ok) {
+        throw new Error(`API request failed with status ${response.status}`);
+      }
+      if (response.status === 204) {
+        return undefined as T;
+      }
+      return (await response.json()) as T;
+    } catch (error) {
+      if (fallback) {
+        return await fallback();
+      }
+      throw error;
+    }
+  }
+}
+
+export const apiClient = new ApiClient(import.meta.env.VITE_API_URL || '');

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -1,0 +1,81 @@
+export type InsightType = 'irrigation' | 'disease' | 'battery';
+export type InsightSeverity = 'low' | 'medium' | 'high';
+
+export interface OrgOverview {
+  totalNodes: number;
+  onlineNodes: number;
+  avgSoilMoisture: number;
+  batteryWarnings: number;
+}
+
+export interface NodeSummary {
+  id: string;
+  name: string;
+  soilMoisture: number;
+  battery: number;
+  signalStrength: number;
+  lastSeen: string;
+  status: 'online' | 'offline';
+}
+
+export interface Site {
+  id: string;
+  name: string;
+  description?: string;
+  coordinates: {
+    lat: number;
+    lng: number;
+  };
+  nodes: NodeSummary[];
+}
+
+export interface NodeTelemetryPoint {
+  timestamp: string;
+  soilMoisture: number;
+  soilTemp: number;
+  airTemp: number;
+  humidity: number;
+  light: number;
+  battery: number;
+  nodeId?: string;
+}
+
+export interface NodeDetail extends NodeSummary {
+  siteId: string;
+  firmwareVersion: string;
+  publishIntervalSec: number;
+}
+
+export interface Insight {
+  id: string;
+  siteId: string;
+  nodeId: string;
+  type: InsightType;
+  severity: InsightSeverity;
+  message: string;
+  timestamp: string;
+  acknowledged?: boolean;
+}
+
+export interface CommandPayload {
+  nodeId: string;
+  publishIntervalSec: number;
+  otaUrl?: string;
+}
+
+export interface AuthTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface AuthResponse {
+  user: User;
+  tokens: AuthTokens;
+}
+
+export interface User {
+  id: string;
+  email: string;
+  name: string;
+  orgId: string;
+}

--- a/web/src/utils/index.ts
+++ b/web/src/utils/index.ts
@@ -1,0 +1,28 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}
+
+export const formatPercentage = (value: number, digits = 0) =>
+  `${value.toFixed(digits)}%`;
+
+export const formatDateTime = (value: string | number | Date) =>
+  new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit'
+  }).format(new Date(value));
+
+export const formatTimeAgo = (value: string | number | Date) => {
+  const diffMs = Date.now() - new Date(value).getTime();
+  const diffMinutes = Math.max(Math.floor(diffMs / 60000), 0);
+  if (diffMinutes < 1) return 'just now';
+  if (diffMinutes < 60) return `${diffMinutes}m ago`;
+  const diffHours = Math.floor(diffMinutes / 60);
+  if (diffHours < 24) return `${diffHours}h ago`;
+  const diffDays = Math.floor(diffHours / 24);
+  return `${diffDays}d ago`;
+};

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -1,0 +1,50 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  darkMode: ['class'],
+  content: ['./index.html', './src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {
+      colors: {
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))'
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))'
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))'
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))'
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))'
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))'
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))'
+        }
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)'
+      }
+    }
+  },
+  plugins: [require('tailwindcss-animate')]
+};

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/web/tsconfig.node.json
+++ b/web/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src')
+    }
+  },
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React + TypeScript web workspace with Tailwind, shadcn/ui helpers, and Recharts configuration
- implement authentication context plus login/register flows alongside overview, site, node, and insights routes with reusable UI components
- add live telemetry streaming fallbacks, command publishing support, seeded mock data, and project documentation/environment templates

## Testing
- not run (npm install is blocked in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cb0b36d7bc83228bc230dd4f09ad25