### PR TITLE
Add ArduinoJson include to ESP32 node firmware

### DIFF
--- a/firmware/esp32-node/src/main.cpp
+++ b/firmware/esp32-node/src/main.cpp
@@ -1,6 +1,7 @@
 #include <Arduino.h>
 #include <WiFi.h>
 #include <PubSubClient.h>
+#include <ArduinoJson.h>
 #include "config.h"
 
 static DeviceConfig deviceConfig{


### PR DESCRIPTION
## Summary
- include ArduinoJson in the ESP32 node firmware so StaticJsonDocument and serializeJson resolve during compilation

## Testing
- `pio run` *(fails: command not found in container environment)*
- `python -m platformio run` *(fails: No module named platformio)*

------
https://chatgpt.com/codex/tasks/task_e_68cc30ac79188322ba1c8dc51ab85668