### PR TITLE
fix: switch to timescaledb non-HA image and disable TLS listener for …

### DIFF
--- a/cloud/infrastructure/docker-compose.yml
+++ b/cloud/infrastructure/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.9"
 
 services:
   db:
-    image: timescale/timescaledb-ha:pg14-latest
+    image: timescale/timescaledb:latest-pg14
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_USER: postgres
@@ -33,7 +33,7 @@ services:
     image: eclipse-mosquitto:2
     ports:
       - "1883:1883"   # plain / local dev / simulator
-      - "8883:8883"   # TLS / production gateway
+      # - "8883:8883" # TLS / production gateway — enable when certs are present
     volumes:
       - ./mosquitto/mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
       - ./mosquitto/certs:/mosquitto/certs:ro

--- a/cloud/infrastructure/mosquitto/mosquitto.conf
+++ b/cloud/infrastructure/mosquitto/mosquitto.conf
@@ -8,13 +8,15 @@ listener 1883
 allow_anonymous true
 
 # ── TLS listener (production gateway path) ──────────────────────────────────
-listener 8883
-cafile   /mosquitto/certs/ca.crt
-certfile /mosquitto/certs/server.crt
-keyfile  /mosquitto/certs/server.key
-require_certificate false
-allow_anonymous false
-password_file /mosquitto/config/passwordfile
+# Disabled for local dev — cert files are not present in the repo.
+# To enable: generate certs into cloud/infrastructure/mosquitto/certs/ and uncomment.
+# listener 8883
+# cafile   /mosquitto/certs/ca.crt
+# certfile /mosquitto/certs/server.crt
+# keyfile  /mosquitto/certs/server.key
+# require_certificate false
+# allow_anonymous false
+# password_file /mosquitto/config/passwordfile
 
 # Shared
 persistence false


### PR DESCRIPTION
…local dev

timescaledb-ha exits with code 3 on Windows Docker Desktop; the standard image is more reliable. The 8883 TLS listener is commented out because cert files are gitignored and not present in dev environments.

https://claude.ai/code/session_01PDv12cqtN71zew6RDTjukR