### PR TITLE
fix: replace asyncio-mqtt with aiomqtt in pyproject.toml

### DIFF
--- a/cloud/services/ingestor/pyproject.toml
+++ b/cloud/services/ingestor/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "MQTT ingestion service for VineGuard"
 requires-python = ">=3.10"
 dependencies = [
-    "asyncio-mqtt>=0.16",
+    "aiomqtt>=2.0",
     "pydantic>=2.5",
     "pydantic-settings>=2.0",
     "sqlalchemy[asyncio]>=2.0",


### PR DESCRIPTION
pyproject.toml [project].dependencies takes precedence over setup.cfg install_requires, so the asyncio-mqtt entry there was overriding the fix.

https://claude.ai/code/session_01PDv12cqtN71zew6RDTjukR