### PR TITLE
fix: split ingestor GRANT into separate SELECT and UPDATE statements

### DIFF
--- a/cloud/infrastructure/sql/init_timescaledb.sql
+++ b/cloud/infrastructure/sql/init_timescaledb.sql
@@ -201,7 +201,8 @@ GRANT INSERT ON users TO vineguard_api;
 
 -- Ingestor: insert telemetry, upsert node health
 GRANT INSERT ON telemetry_readings TO vineguard_ingestor;
-GRANT SELECT, UPDATE (last_seen_at, battery_voltage, battery_pct, rssi_last, status) ON nodes TO vineguard_ingestor;
+GRANT SELECT ON nodes TO vineguard_ingestor;
+GRANT UPDATE (last_seen_at, battery_voltage, battery_pct, rssi_last, status) ON nodes TO vineguard_ingestor;
 
 -- Analytics: read domain model, write alerts/recommendations/gdd
 GRANT SELECT ON


### PR DESCRIPTION
GRANT SELECT, UPDATE (cols) is parsed as column-level SELECT (only those 5 cols) + column-level UPDATE. The ingestor needs table-level SELECT to query nodes.id by device_id. Separate statements give table-level SELECT + column-level UPDATE.

https://claude.ai/code/session_01PDv12cqtN71zew6RDTjukR