### PR TITLE
feat: Analytics + Settings pages, device provisioning, infra gap fixes

### DIFF
--- a/cloud/services/api/app/api/v1/nodes.py
+++ b/cloud/services/api/app/api/v1/nodes.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta, timezone
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Query, status
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from ... import models, schemas
@@ -21,7 +21,6 @@ async def list_nodes(
     session: AsyncSession = Depends(get_session),
     _current_user: schemas.UserOut = Depends(get_current_user),
 ) -> list[schemas.NodeOut]:
-    """Return all nodes, optionally filtered by block_id and/or status."""
     query = select(models.nodes).order_by(models.nodes.c.installed_at.desc())
     if block_id is not None:
         query = query.where(models.nodes.c.block_id == block_id)
@@ -32,6 +31,26 @@ async def list_nodes(
     return [schemas.NodeOut(**row._mapping) for row in rows]
 
 
+@router.get("/nodes/unregistered-devices", response_model=list[schemas.UnregisteredDevice])
+async def list_unregistered_devices(
+    session: AsyncSession = Depends(get_session),
+    _current_user: schemas.UserOut = Depends(get_current_user),
+) -> list[schemas.UnregisteredDevice]:
+    """Return device_ids sending telemetry that have no registered node entry."""
+    result = await session.execute(
+        select(
+            models.telemetry_readings.c.device_id,
+            func.max(models.telemetry_readings.c.recorded_at).label("last_seen_at"),
+            func.count().label("reading_count"),
+        )
+        .where(models.telemetry_readings.c.node_id.is_(None))
+        .group_by(models.telemetry_readings.c.device_id)
+        .order_by(func.max(models.telemetry_readings.c.recorded_at).desc())
+    )
+    rows = result.fetchall()
+    return [schemas.UnregisteredDevice(**row._mapping) for row in rows]
+
+
 @router.post("/nodes", response_model=schemas.NodeOut, status_code=status.HTTP_201_CREATED)
 async def create_node(
     payload: schemas.NodeCreate,
@@ -39,14 +58,12 @@ async def create_node(
     _current_user: schemas.UserOut = Depends(require_operator),
 ) -> schemas.NodeOut:
     """Provision a new node (operator+ only)."""
-    # Verify block exists
     br = await session.execute(
         select(models.blocks).where(models.blocks.c.id == payload.block_id)
     )
     if br.fetchone() is None:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Block not found")
 
-    # Check for duplicate device_id
     existing = await session.execute(
         select(models.nodes).where(models.nodes.c.device_id == payload.device_id)
     )
@@ -81,7 +98,6 @@ async def get_node(
     session: AsyncSession = Depends(get_session),
     _current_user: schemas.UserOut = Depends(get_current_user),
 ) -> schemas.NodeOut:
-    """Return a single node by ID."""
     result = await session.execute(
         select(models.nodes).where(models.nodes.c.id == node_id)
     )
@@ -94,13 +110,11 @@ async def get_node(
 @router.get("/nodes/{node_id}/telemetry", response_model=list[schemas.TelemetryOut])
 async def get_node_telemetry(
     node_id: UUID,
-    limit: int = Query(default=100, ge=1, le=1000),
+    limit: int = Query(default=200, ge=1, le=1000),
     hours: int = Query(default=24, ge=1, le=720),
     session: AsyncSession = Depends(get_session),
     _current_user: schemas.UserOut = Depends(get_current_user),
 ) -> list[schemas.TelemetryOut]:
-    """Return telemetry readings for a single node."""
-    # Verify node exists
     nr = await session.execute(
         select(models.nodes).where(models.nodes.c.id == node_id)
     )

--- a/cloud/services/api/app/schemas.py
+++ b/cloud/services/api/app/schemas.py
@@ -238,6 +238,18 @@ class GDDEntry(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Device provisioning
+# ---------------------------------------------------------------------------
+
+class UnregisteredDevice(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    device_id: str
+    last_seen_at: datetime
+    reading_count: int
+
+
+# ---------------------------------------------------------------------------
 # Analytics (kept from original)
 # ---------------------------------------------------------------------------
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,22 +2,26 @@ import { Route, Routes } from 'react-router-dom';
 
 import { Layout } from './components/Layout';
 import { AlertsCenter } from './pages/AlertsCenter';
+import { AnalyticsPage } from './pages/AnalyticsPage';
 import { BlockDetail } from './pages/BlockDetail';
 import { BlocksPage } from './pages/BlocksPage';
 import { NodeDetail } from './pages/NodeDetail';
 import { Overview } from './pages/Overview';
 import { Recommendations } from './pages/Recommendations';
+import { SettingsPage } from './pages/SettingsPage';
 
 export default function App() {
   return (
     <Routes>
       <Route element={<Layout />}>
         <Route index element={<Overview />} />
+        <Route path="analytics" element={<AnalyticsPage />} />
         <Route path="blocks" element={<BlocksPage />} />
         <Route path="blocks/:blockId" element={<BlockDetail />} />
         <Route path="nodes/:nodeId" element={<NodeDetail />} />
         <Route path="alerts" element={<AlertsCenter />} />
         <Route path="recommendations" element={<Recommendations />} />
+        <Route path="settings" element={<SettingsPage />} />
       </Route>
     </Routes>
   );

--- a/web/src/components/Layout.tsx
+++ b/web/src/components/Layout.tsx
@@ -12,17 +12,17 @@ import {
 import { NavLink, Outlet } from 'react-router-dom';
 
 const NAV_ITEMS = [
-  { to: '/', label: 'Overview', icon: Home, end: true, enabled: true },
-  { to: '/blocks', label: 'Blocks', icon: Layers, end: false, enabled: true },
-  { to: '/alerts', label: 'Alerts', icon: AlertTriangle, end: false, enabled: true },
-  { to: '/recommendations', label: 'Recommendations', icon: List, end: false, enabled: true },
+  { to: '/', label: 'Overview', icon: Home, end: true },
+  { to: '/analytics', label: 'Analytics', icon: BarChart2, end: false },
+  { to: '/blocks', label: 'Blocks', icon: Layers, end: false },
+  { to: '/alerts', label: 'Alerts', icon: AlertTriangle, end: false },
+  { to: '/recommendations', label: 'Recommendations', icon: List, end: false },
+  { to: '/settings', label: 'Settings', icon: Settings, end: false },
 ];
 
 const NAV_SOON = [
-  { label: 'Analytics', icon: BarChart2 },
   { label: 'Field Map', icon: Map },
   { label: 'Reports', icon: FileText },
-  { label: 'Settings', icon: Settings },
 ];
 
 export function Layout() {
@@ -77,21 +77,23 @@ export function Layout() {
           ))}
         </nav>
 
-        {/* Coming soon nav */}
-        <nav className="flex flex-col gap-0.5 px-3 pb-3">
-          <p className="mb-1 mt-3 px-3 text-[10px] font-semibold uppercase tracking-widest text-slate-700">
-            Coming Soon
-          </p>
-          {NAV_SOON.map(({ label, icon: Icon }) => (
-            <div
-              key={label}
-              className="flex cursor-not-allowed items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-700"
-            >
-              <Icon className="h-4 w-4 flex-shrink-0 text-slate-700" />
-              {label}
-            </div>
-          ))}
-        </nav>
+        {/* Coming soon */}
+        {NAV_SOON.length > 0 && (
+          <nav className="flex flex-col gap-0.5 px-3 pb-3">
+            <p className="mb-1 mt-2 px-3 text-[10px] font-semibold uppercase tracking-widest text-slate-700">
+              Coming Soon
+            </p>
+            {NAV_SOON.map(({ label, icon: Icon }) => (
+              <div
+                key={label}
+                className="flex cursor-not-allowed items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-slate-700"
+              >
+                <Icon className="h-4 w-4 flex-shrink-0 text-slate-700" />
+                {label}
+              </div>
+            ))}
+          </nav>
+        )}
 
         {/* Footer */}
         <div className="mt-auto border-t border-slate-800/70 px-5 py-4">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   Node,
   Recommendation,
   TelemetryReading,
+  UnregisteredDevice,
   Vineyard,
 } from './types';
 
@@ -51,7 +52,7 @@ export async function fetchBlockTelemetry(
 ): Promise<TelemetryReading[]> {
   const { data } = await axios.get<TelemetryReading[]>(
     `${API_BASE}/api/v1/blocks/${blockId}/telemetry`,
-    { headers, params: { limit: 100, hours } },
+    { headers, params: { limit: 200, hours } },
   );
   return data;
 }
@@ -84,6 +85,27 @@ export async function fetchNodeTelemetry(
   const { data } = await axios.get<TelemetryReading[]>(
     `${API_BASE}/api/v1/nodes/${nodeId}/telemetry`,
     { headers, params: { limit: 200, hours } },
+  );
+  return data;
+}
+
+export async function createNode(payload: {
+  device_id: string;
+  name: string;
+  tier: 'basic' | 'precision_plus';
+  block_id: string;
+  lat?: number;
+  lon?: number;
+  firmware_version?: string;
+}): Promise<Node> {
+  const { data } = await axios.post<Node>(`${API_BASE}/api/v1/nodes`, payload, { headers });
+  return data;
+}
+
+export async function fetchUnregisteredDevices(): Promise<UnregisteredDevice[]> {
+  const { data } = await axios.get<UnregisteredDevice[]>(
+    `${API_BASE}/api/v1/nodes/unregistered-devices`,
+    { headers },
   );
   return data;
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -101,6 +101,12 @@ export interface DashboardOverview {
   stale_node_count: number;
 }
 
+export interface UnregisteredDevice {
+  device_id: string;
+  last_seen_at: string;
+  reading_count: number;
+}
+
 export interface GDDEntry {
   vineyard_id: string;
   date: string;

--- a/web/src/pages/AnalyticsPage.tsx
+++ b/web/src/pages/AnalyticsPage.tsx
@@ -1,0 +1,395 @@
+import { useEffect, useState } from 'react';
+import {
+  Activity,
+  BarChart2,
+  Droplets,
+  Thermometer,
+  Wind,
+  Zap,
+} from 'lucide-react';
+import {
+  Area,
+  AreaChart,
+  CartesianGrid,
+  Legend,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import { fetchBlock, fetchBlocks, fetchNodeTelemetry, fetchVineyards } from '../lib/api';
+import type { Block, BlockWithNodes, TelemetryReading } from '../lib/types';
+
+const HOURS_OPTIONS = [
+  { label: '6h', value: 6 },
+  { label: '24h', value: 24 },
+  { label: '48h', value: 48 },
+  { label: '7d', value: 168 },
+];
+
+function fmtTick(ts: string, hours: number): string {
+  const d = new Date(ts);
+  if (hours <= 48) return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  return d.toLocaleDateString([], { month: 'short', day: 'numeric' });
+}
+
+function ChartCard({
+  title,
+  icon: Icon,
+  color,
+  children,
+}: {
+  title: string;
+  icon: React.ElementType;
+  color: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/60 p-5">
+      <div className="mb-4 flex items-center gap-2">
+        <Icon className="h-4 w-4 flex-shrink-0" style={{ color }} />
+        <h3 className="text-sm font-semibold text-slate-300">{title}</h3>
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function CustomTooltip({
+  active,
+  payload,
+  label,
+  unit = '',
+}: {
+  active?: boolean;
+  payload?: { color: string; name: string; value: number }[];
+  label?: string;
+  unit?: string;
+}) {
+  if (!active || !payload?.length) return null;
+  return (
+    <div className="rounded-lg border border-slate-700 bg-slate-900 px-3 py-2 shadow-xl">
+      <p className="mb-1 text-[10px] text-slate-400">
+        {label ? new Date(label).toLocaleString() : ''}
+      </p>
+      {payload.map((p) => (
+        <p key={p.name} className="text-sm font-semibold" style={{ color: p.color }}>
+          {p.name}: {p.value.toFixed(1)}
+          {unit}
+        </p>
+      ))}
+    </div>
+  );
+}
+
+const axisStyle = { fill: '#475569', fontSize: 10 };
+const gridStyle = { strokeDasharray: '3 3', stroke: '#1e293b' };
+
+export function AnalyticsPage() {
+  const [blocks, setBlocks] = useState<Block[]>([]);
+  const [selectedBlockId, setSelectedBlockId] = useState<string>('');
+  const [blockDetail, setBlockDetail] = useState<BlockWithNodes | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string>('');
+  const [telemetry, setTelemetry] = useState<TelemetryReading[]>([]);
+  const [hours, setHours] = useState(24);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchVineyards()
+      .then((vs) => {
+        if (vs.length === 0) return;
+        return fetchBlocks(vs[0].id);
+      })
+      .then((bs) => {
+        if (!bs || bs.length === 0) return;
+        setBlocks(bs);
+        setSelectedBlockId(bs[0].id);
+      })
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load'));
+  }, []);
+
+  useEffect(() => {
+    if (!selectedBlockId) return;
+    fetchBlock(selectedBlockId).then((bd) => {
+      setBlockDetail(bd);
+      setSelectedNodeId(bd.nodes[0]?.id ?? '');
+    });
+  }, [selectedBlockId]);
+
+  useEffect(() => {
+    if (!selectedNodeId) return;
+    setLoading(true);
+    setTelemetry([]);
+    fetchNodeTelemetry(selectedNodeId, hours)
+      .then(setTelemetry)
+      .catch((e) => setError(e instanceof Error ? e.message : 'Failed to load telemetry'))
+      .finally(() => setLoading(false));
+  }, [selectedNodeId, hours]);
+
+  const chartData = [...telemetry].reverse();
+  const hasLeafWet = chartData.some((r) => r.leaf_wetness_pct !== null);
+
+  return (
+    <div className="space-y-5 p-6">
+      {/* Header + controls */}
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="text-lg font-semibold text-white">Analytics</h1>
+          <p className="text-xs text-slate-500">Historical sensor trends per node</p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          <select
+            value={selectedBlockId}
+            onChange={(e) => setSelectedBlockId(e.target.value)}
+            className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-200 focus:border-emerald-500 focus:outline-none"
+          >
+            <option value="" disabled>Select block…</option>
+            {blocks.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.name}
+              </option>
+            ))}
+          </select>
+
+          {blockDetail && blockDetail.nodes.length > 0 && (
+            <select
+              value={selectedNodeId}
+              onChange={(e) => setSelectedNodeId(e.target.value)}
+              className="rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-200 focus:border-emerald-500 focus:outline-none"
+            >
+              {blockDetail.nodes.map((n) => (
+                <option key={n.id} value={n.id}>
+                  {n.name} · {n.device_id}
+                </option>
+              ))}
+            </select>
+          )}
+
+          <div className="flex overflow-hidden rounded-lg border border-slate-700">
+            {HOURS_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                onClick={() => setHours(opt.value)}
+                className={`px-3 py-2 text-xs font-medium transition-colors ${
+                  hours === opt.value
+                    ? 'bg-emerald-500/20 text-emerald-400'
+                    : 'bg-slate-800 text-slate-400 hover:bg-slate-700 hover:text-slate-200'
+                }`}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-xl border border-red-800/30 bg-red-950/20 p-4">
+          <p className="text-sm text-red-400">{error}</p>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex h-64 items-center justify-center">
+          <div className="flex items-center gap-3">
+            <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-400" />
+            <span className="text-sm text-slate-400">Loading telemetry…</span>
+          </div>
+        </div>
+      ) : chartData.length === 0 ? (
+        <div className="flex h-64 flex-col items-center justify-center gap-3 rounded-xl border border-slate-800 bg-slate-900/40">
+          <BarChart2 className="h-10 w-10 text-slate-700" />
+          <div className="text-center">
+            <p className="text-sm font-medium text-slate-400">No data for this period</p>
+            <p className="mt-1 text-xs text-slate-600">
+              Start the simulator:{' '}
+              <code className="text-slate-500">docker compose --profile demo up -d</code>
+            </p>
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
+          {/* Soil Moisture */}
+          <ChartCard title="Soil Moisture (VWC %)" icon={Droplets} color="#10b981">
+            <ResponsiveContainer width="100%" height={220}>
+              <AreaChart data={chartData}>
+                <defs>
+                  <linearGradient id="gm" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#10b981" stopOpacity={0.3} />
+                    <stop offset="100%" stopColor="#10b981" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid {...gridStyle} />
+                <XAxis
+                  dataKey="recorded_at"
+                  tickFormatter={(v) => fmtTick(v, hours)}
+                  tick={axisStyle}
+                  minTickGap={50}
+                />
+                <YAxis tick={axisStyle} domain={[0, 100]} unit="%" width={40} />
+                <Tooltip content={<CustomTooltip unit="%" />} />
+                <Area
+                  type="monotone"
+                  dataKey="soil_moisture"
+                  name="VWC"
+                  stroke="#10b981"
+                  strokeWidth={2}
+                  fill="url(#gm)"
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </ChartCard>
+
+          {/* Temperature */}
+          <ChartCard title="Temperature (°C)" icon={Thermometer} color="#f59e0b">
+            <ResponsiveContainer width="100%" height={220}>
+              <LineChart data={chartData}>
+                <CartesianGrid {...gridStyle} />
+                <XAxis
+                  dataKey="recorded_at"
+                  tickFormatter={(v) => fmtTick(v, hours)}
+                  tick={axisStyle}
+                  minTickGap={50}
+                />
+                <YAxis tick={axisStyle} unit="°" width={35} />
+                <Tooltip content={<CustomTooltip unit="°C" />} />
+                <Legend wrapperStyle={{ fontSize: '11px', color: '#94a3b8' }} />
+                <Line
+                  type="monotone"
+                  dataKey="ambient_temp_c"
+                  name="Air"
+                  stroke="#f59e0b"
+                  strokeWidth={2}
+                  dot={false}
+                  isAnimationActive={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="soil_temp_c"
+                  name="Soil"
+                  stroke="#fb923c"
+                  strokeWidth={1.5}
+                  strokeDasharray="4 2"
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartCard>
+
+          {/* Humidity */}
+          <ChartCard title="Relative Humidity (%)" icon={Wind} color="#38bdf8">
+            <ResponsiveContainer width="100%" height={220}>
+              <AreaChart data={chartData}>
+                <defs>
+                  <linearGradient id="gh" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#38bdf8" stopOpacity={0.25} />
+                    <stop offset="100%" stopColor="#38bdf8" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid {...gridStyle} />
+                <XAxis
+                  dataKey="recorded_at"
+                  tickFormatter={(v) => fmtTick(v, hours)}
+                  tick={axisStyle}
+                  minTickGap={50}
+                />
+                <YAxis tick={axisStyle} domain={[0, 100]} unit="%" width={40} />
+                <Tooltip content={<CustomTooltip unit="%" />} />
+                <Area
+                  type="monotone"
+                  dataKey="ambient_humidity"
+                  name="RH"
+                  stroke="#38bdf8"
+                  strokeWidth={2}
+                  fill="url(#gh)"
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </ChartCard>
+
+          {/* Light Lux */}
+          <ChartCard title="Light Intensity (lux)" icon={Zap} color="#a78bfa">
+            <ResponsiveContainer width="100%" height={220}>
+              <AreaChart data={chartData}>
+                <defs>
+                  <linearGradient id="gl" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="0%" stopColor="#a78bfa" stopOpacity={0.25} />
+                    <stop offset="100%" stopColor="#a78bfa" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid {...gridStyle} />
+                <XAxis
+                  dataKey="recorded_at"
+                  tickFormatter={(v) => fmtTick(v, hours)}
+                  tick={axisStyle}
+                  minTickGap={50}
+                />
+                <YAxis
+                  tick={axisStyle}
+                  width={45}
+                  tickFormatter={(v) => (v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v))}
+                />
+                <Tooltip content={<CustomTooltip unit=" lux" />} />
+                <Area
+                  type="monotone"
+                  dataKey="light_lux"
+                  name="Lux"
+                  stroke="#a78bfa"
+                  strokeWidth={2}
+                  fill="url(#gl)"
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </AreaChart>
+            </ResponsiveContainer>
+          </ChartCard>
+
+          {/* Leaf Wetness — precision_plus nodes only */}
+          {hasLeafWet && (
+            <ChartCard title="Leaf Wetness (%)" icon={Activity} color="#34d399">
+              <ResponsiveContainer width="100%" height={220}>
+                <AreaChart data={chartData}>
+                  <defs>
+                    <linearGradient id="glw" x1="0" y1="0" x2="0" y2="1">
+                      <stop offset="0%" stopColor="#34d399" stopOpacity={0.25} />
+                      <stop offset="100%" stopColor="#34d399" stopOpacity={0} />
+                    </linearGradient>
+                  </defs>
+                  <CartesianGrid {...gridStyle} />
+                  <XAxis
+                    dataKey="recorded_at"
+                    tickFormatter={(v) => fmtTick(v, hours)}
+                    tick={axisStyle}
+                    minTickGap={50}
+                  />
+                  <YAxis tick={axisStyle} domain={[0, 100]} unit="%" width={40} />
+                  <Tooltip content={<CustomTooltip unit="%" />} />
+                  <Area
+                    type="monotone"
+                    dataKey="leaf_wetness_pct"
+                    name="Leaf Wet"
+                    stroke="#34d399"
+                    strokeWidth={2}
+                    fill="url(#glw)"
+                    dot={false}
+                    isAnimationActive={false}
+                  />
+                </AreaChart>
+              </ResponsiveContainer>
+            </ChartCard>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1,0 +1,365 @@
+import { useCallback, useEffect, useState } from 'react';
+import { CheckCircle2, Clock, PlusCircle, Radio, Server, Wifi, WifiOff } from 'lucide-react';
+
+import { createNode, fetchBlocks, fetchNodes, fetchUnregisteredDevices, fetchVineyards } from '../lib/api';
+import type { Block, Node, UnregisteredDevice, Vineyard } from '../lib/types';
+
+const STATUS_STYLES: Record<string, string> = {
+  active: 'bg-emerald-500/15 text-emerald-400 border-emerald-800/30',
+  stale: 'bg-amber-500/15 text-amber-400 border-amber-800/30',
+  inactive: 'bg-slate-700/40 text-slate-500 border-slate-700/30',
+};
+
+const TIER_LABELS: Record<string, string> = {
+  basic: 'Basic',
+  precision_plus: 'Precision+',
+};
+
+function SectionCard({
+  title,
+  subtitle,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="rounded-xl border border-slate-800 bg-slate-900/60">
+      <div className="border-b border-slate-800 px-5 py-4">
+        <h2 className="text-sm font-semibold text-white">{title}</h2>
+        {subtitle && <p className="mt-0.5 text-xs text-slate-500">{subtitle}</p>}
+      </div>
+      <div className="p-5">{children}</div>
+    </div>
+  );
+}
+
+function NodeRow({ node }: { node: Node }) {
+  const lastSeen = node.last_seen_at
+    ? new Date(node.last_seen_at).toLocaleString()
+    : 'Never';
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-b border-slate-800/60 py-3 last:border-0">
+      <div className="flex items-center gap-3 min-w-0">
+        {node.status === 'active' ? (
+          <Wifi className="h-4 w-4 flex-shrink-0 text-emerald-400" />
+        ) : (
+          <WifiOff className="h-4 w-4 flex-shrink-0 text-slate-600" />
+        )}
+        <div className="min-w-0">
+          <p className="text-sm font-medium text-slate-200">{node.name}</p>
+          <p className="text-xs text-slate-500">
+            <code className="font-mono">{node.device_id}</code>
+            {' · '}
+            {TIER_LABELS[node.tier] ?? node.tier}
+          </p>
+        </div>
+      </div>
+      <div className="flex items-center gap-3">
+        <span className="text-xs text-slate-500">{lastSeen}</span>
+        <span
+          className={`rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wide ${
+            STATUS_STYLES[node.status] ?? STATUS_STYLES.inactive
+          }`}
+        >
+          {node.status}
+        </span>
+        {node.battery_voltage != null && (
+          <span
+            className={`text-xs ${
+              node.battery_voltage < 3.4
+                ? 'text-red-400'
+                : node.battery_voltage < 3.6
+                ? 'text-amber-400'
+                : 'text-emerald-400'
+            }`}
+          >
+            {node.battery_voltage.toFixed(2)}V
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RegisterNodeForm({
+  blocks,
+  onRegistered,
+}: {
+  blocks: Block[];
+  onRegistered: () => void;
+}) {
+  const [deviceId, setDeviceId] = useState('');
+  const [name, setName] = useState('');
+  const [tier, setTier] = useState<'basic' | 'precision_plus'>('basic');
+  const [blockId, setBlockId] = useState(blocks[0]?.id ?? '');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!deviceId.trim() || !name.trim() || !blockId) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await createNode({ device_id: deviceId.trim(), name: name.trim(), tier, block_id: blockId });
+      setDeviceId('');
+      setName('');
+      setSuccess(true);
+      setTimeout(() => setSuccess(false), 3000);
+      onRegistered();
+    } catch (err: unknown) {
+      const msg =
+        err instanceof Error
+          ? err.message
+          : 'Registration failed';
+      setError(msg);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const inputClass =
+    'w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-200 placeholder-slate-600 focus:border-emerald-500 focus:outline-none';
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <div>
+          <label className="mb-1.5 block text-xs text-slate-400">Device ID</label>
+          <input
+            className={inputClass}
+            placeholder="e.g. vg-node-004"
+            value={deviceId}
+            onChange={(e) => setDeviceId(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-xs text-slate-400">Display Name</label>
+          <input
+            className={inputClass}
+            placeholder="e.g. Block C — East Row"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="mb-1.5 block text-xs text-slate-400">Block</label>
+          <select
+            className={inputClass}
+            value={blockId}
+            onChange={(e) => setBlockId(e.target.value)}
+            required
+          >
+            {blocks.map((b) => (
+              <option key={b.id} value={b.id}>
+                {b.name} ({b.variety})
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
+          <label className="mb-1.5 block text-xs text-slate-400">Tier</label>
+          <select
+            className={inputClass}
+            value={tier}
+            onChange={(e) => setTier(e.target.value as 'basic' | 'precision_plus')}
+          >
+            <option value="basic">Basic</option>
+            <option value="precision_plus">Precision+</option>
+          </select>
+        </div>
+      </div>
+
+      {error && (
+        <p className="rounded-lg border border-red-800/30 bg-red-950/20 px-3 py-2 text-xs text-red-400">
+          {error}
+        </p>
+      )}
+      {success && (
+        <div className="flex items-center gap-2 rounded-lg border border-emerald-800/30 bg-emerald-950/20 px-3 py-2">
+          <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+          <p className="text-xs text-emerald-400">Node registered successfully.</p>
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <PlusCircle className="h-4 w-4" />
+        {submitting ? 'Registering…' : 'Register Node'}
+      </button>
+    </form>
+  );
+}
+
+export function SettingsPage() {
+  const [vineyard, setVineyard] = useState<Vineyard | null>(null);
+  const [nodes, setNodes] = useState<Node[]>([]);
+  const [blocks, setBlocks] = useState<Block[]>([]);
+  const [unregistered, setUnregistered] = useState<UnregisteredDevice[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const reload = useCallback(async () => {
+    try {
+      const vs = await fetchVineyards();
+      if (vs.length === 0) return;
+      setVineyard(vs[0]);
+      const [ns, bs, ur] = await Promise.all([
+        fetchNodes(),
+        fetchBlocks(vs[0].id),
+        fetchUnregisteredDevices(),
+      ]);
+      setNodes(ns);
+      setBlocks(bs);
+      setUnregistered(ur);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <span className="h-2 w-2 animate-pulse rounded-full bg-emerald-400" />
+      </div>
+    );
+  }
+
+  const activeNodes = nodes.filter((n) => n.status === 'active');
+  const staleNodes = nodes.filter((n) => n.status !== 'active');
+
+  return (
+    <div className="space-y-6 p-6">
+      <div>
+        <h1 className="text-lg font-semibold text-white">Settings</h1>
+        <p className="text-xs text-slate-500">Vineyard configuration and device management</p>
+      </div>
+
+      {/* Vineyard summary */}
+      {vineyard && (
+        <SectionCard title="Vineyard" subtitle="Current estate">
+          <div className="grid grid-cols-2 gap-4 text-sm sm:grid-cols-4">
+            {[
+              { label: 'Name', value: vineyard.name },
+              { label: 'Region', value: vineyard.region },
+              { label: 'Owner', value: vineyard.owner_name },
+              { label: 'Blocks', value: String(blocks.length) },
+            ].map(({ label, value }) => (
+              <div key={label}>
+                <p className="text-xs text-slate-500">{label}</p>
+                <p className="mt-0.5 font-medium text-slate-200">{value || '—'}</p>
+              </div>
+            ))}
+          </div>
+        </SectionCard>
+      )}
+
+      {/* Node fleet */}
+      <SectionCard
+        title="Registered Nodes"
+        subtitle={`${activeNodes.length} online · ${staleNodes.length} stale/inactive`}
+      >
+        {nodes.length === 0 ? (
+          <p className="text-sm text-slate-500">No nodes registered yet.</p>
+        ) : (
+          <div className="divide-y divide-slate-800/60">
+            {nodes.map((n) => (
+              <NodeRow key={n.id} node={n} />
+            ))}
+          </div>
+        )}
+      </SectionCard>
+
+      {/* Unregistered devices */}
+      {unregistered.length > 0 && (
+        <SectionCard
+          title="Unregistered Devices"
+          subtitle="These device IDs are sending telemetry but have no node record. Register them below."
+        >
+          <div className="space-y-2">
+            {unregistered.map((d) => (
+              <div
+                key={d.device_id}
+                className="flex items-center justify-between rounded-lg border border-amber-800/20 bg-amber-950/10 px-4 py-3"
+              >
+                <div className="flex items-center gap-3">
+                  <Radio className="h-4 w-4 text-amber-400" />
+                  <div>
+                    <code className="text-sm text-amber-300">{d.device_id}</code>
+                    <p className="text-xs text-slate-500">
+                      {d.reading_count} readings · last{' '}
+                      {new Date(d.last_seen_at).toLocaleString()}
+                    </p>
+                  </div>
+                </div>
+                <span className="rounded-full border border-amber-800/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-400">
+                  Unregistered
+                </span>
+              </div>
+            ))}
+          </div>
+        </SectionCard>
+      )}
+
+      {/* Register new node */}
+      <SectionCard
+        title="Register New Node"
+        subtitle="Provision a device ID to a block before deployment. Telemetry will be attributed once registered."
+      >
+        {blocks.length === 0 ? (
+          <p className="text-sm text-slate-500">No blocks found — seed the demo data first.</p>
+        ) : (
+          <RegisterNodeForm blocks={blocks} onRegistered={reload} />
+        )}
+      </SectionCard>
+
+      {/* MQTT info */}
+      <SectionCard
+        title="Gateway Connection"
+        subtitle="Configuration for hardware gateways to connect to this broker"
+      >
+        <div className="space-y-3 font-mono text-xs">
+          {[
+            { label: 'MQTT Broker (plain)', value: 'mqtt://localhost:1883' },
+            { label: 'MQTT Broker (TLS — prod)', value: 'mqtts://your-server:8883' },
+            { label: 'Topic', value: 'vineguard/telemetry' },
+            { label: 'Payload format', value: 'JSON · schema_version: "1.0"' },
+          ].map(({ label, value }) => (
+            <div key={label} className="flex flex-wrap items-center gap-2">
+              <span className="w-44 flex-shrink-0 text-slate-500">{label}</span>
+              <code className="rounded bg-slate-800 px-2 py-0.5 text-emerald-300">{value}</code>
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 rounded-lg border border-slate-700/50 bg-slate-800/40 p-4">
+          <p className="text-xs font-semibold text-slate-400">Minimum payload (v1 schema)</p>
+          <pre className="mt-2 text-[11px] leading-relaxed text-slate-300">{`{
+  "schema_version": "1.0",
+  "device_id": "vg-node-001",
+  "sensors": {
+    "soil_moisture_pct": 24.5,
+    "soil_temp_c": 18.2,
+    "ambient_temp_c": 21.0,
+    "ambient_humidity_pct": 62.0,
+    "light_lux": 32000
+  },
+  "meta": {
+    "battery_voltage": 3.87
+  }
+}`}</pre>
+        </div>
+      </SectionCard>
+    </div>
+  );
+}


### PR DESCRIPTION
Backend:
- GET /api/v1/nodes/unregistered-devices — returns device_ids sending telemetry with no registered node entry (for hardware discovery)
- schemas.UnregisteredDevice — new response schema
- nodes.py rewritten cleanly (removed duplicate routes from prior edit)
- Node telemetry default limit raised to 200

Frontend:
- AnalyticsPage (/analytics) — recharts time-series charts per node: soil moisture, air+soil temp, humidity, light lux, leaf wetness (P+) with 6h/24h/48h/7d range selector and block/node dropdowns
- SettingsPage (/settings) — node fleet table with status/battery, unregistered device alerts, register-new-node form (calls POST /nodes), gateway connection reference with payload schema example
- Layout: Analytics and Settings now active nav items; Field Map and Reports remain Coming Soon
- api.ts: added createNode(), fetchUnregisteredDevices(), fetchBlocks limit raised to 200
- types.ts: added UnregisteredDevice interface

Simulator note documented: requires --profile demo flag:
  docker compose --profile demo up -d

https://claude.ai/code/session_01PDv12cqtN71zew6RDTjukR