### PR TITLE
Grant SELECT on telemetry_readings to vineguard_ingestor to support INSERT ... RETURNING

### DIFF
--- a/cloud/infrastructure/sql/init_timescaledb.sql
+++ b/cloud/infrastructure/sql/init_timescaledb.sql
@@ -209,7 +209,9 @@ GRANT UPDATE (is_acknowledged, acknowledged_at) ON recommendations TO vineguard_
 GRANT INSERT ON users TO vineguard_api;
 
 -- Ingestor: insert telemetry, upsert node health
-GRANT INSERT ON telemetry_readings TO vineguard_ingestor;
+-- NOTE: ingestor uses INSERT ... RETURNING *, which requires SELECT on
+-- returned columns in PostgreSQL.
+GRANT INSERT, SELECT ON telemetry_readings TO vineguard_ingestor;
 GRANT SELECT ON nodes TO vineguard_ingestor;
 GRANT UPDATE (last_seen_at, battery_voltage, battery_pct, rssi_last, status) ON nodes TO vineguard_ingestor;
 

--- a/cloud/infrastructure/sql/repair_missing_tables.sql
+++ b/cloud/infrastructure/sql/repair_missing_tables.sql
@@ -110,7 +110,9 @@ GRANT UPDATE (is_active, resolved_at)              ON alerts          TO vinegua
 GRANT UPDATE (is_acknowledged, acknowledged_at)    ON recommendations TO vineguard_api;
 
 -- Ingestor role
-GRANT INSERT ON telemetry_readings TO vineguard_ingestor;
+-- NOTE: ingestor uses INSERT ... RETURNING *, which requires SELECT on
+-- returned columns in PostgreSQL.
+GRANT INSERT, SELECT ON telemetry_readings TO vineguard_ingestor;
 GRANT SELECT ON nodes TO vineguard_ingestor;
 GRANT UPDATE (last_seen_at, battery_voltage, battery_pct, rssi_last, status) ON nodes TO vineguard_ingestor;
 


### PR DESCRIPTION
### Motivation
- Ensure the ingestor role can use `INSERT ... RETURNING` against `telemetry_readings` by granting it `SELECT` on the table.

### Description
- Add `SELECT` to the `GRANT` for `telemetry_readings` to `vineguard_ingestor` in `cloud/infrastructure/sql/init_timescaledb.sql` and `cloud/infrastructure/sql/repair_missing_tables.sql`, and include a short explanatory comment.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee31dccb5c8322a940871902c92c9c)